### PR TITLE
Set parent after children were set.

### DIFF
--- a/src/Agents.Net/Message.cs
+++ b/src/Agents.Net/Message.cs
@@ -41,9 +41,6 @@ namespace Agents.Net
         
         public void ReplaceWith(Message message)
         {
-            message.parent = parent;
-            parent.RemoveChild(this);
-            parent.AddChild(message);
             message.childMessages.Clear();
             foreach (Message childMessage in childMessages)
             {
@@ -51,6 +48,9 @@ namespace Agents.Net
             }
             message.predecessorMessages = predecessorMessages;
             message.SwitchDomain(MessageDomain);
+            message.parent = parent;
+            parent.RemoveChild(this);
+            parent.AddChild(message);
         }
 
         internal IEnumerable<Message> Predecessors => predecessorMessages;


### PR DESCRIPTION
The problem was that a message did not know its grand children after a child was replaced. For that I needed to first replace the children and afterwards replace the parent.