### PR TITLE
Add consumable messages.

### DIFF
--- a/src/Agents.Net/ConsumableMessage.cs
+++ b/src/Agents.Net/ConsumableMessage.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Agents.Net
+{
+    public abstract class ConsumableMessage : Message, IDisposable
+    {
+        protected ConsumableMessage(Message predecessorMessage, MessageDefinition messageDefinition, params Message[] childMessages) : base(predecessorMessage, messageDefinition, childMessages)
+        {
+        }
+
+        protected ConsumableMessage(IEnumerable<Message> predecessorMessages, MessageDefinition messageDefinition, params Message[] childMessages) : base(predecessorMessages, messageDefinition, childMessages)
+        {
+        }
+
+        public void Consumed()
+        {
+            ConsumeAction?.Invoke();
+        }
+
+        internal Action ConsumeAction { get; set; }
+
+        public abstract void DisposeConsumables();
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                DisposeConsumables();
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+    }
+}


### PR DESCRIPTION
These messages are Disposed as soon as all consuming agents are finished.
This should prevent memory leaks as long as the agents report that they consumed the message. This must be checked in a code analyser.