### PR TITLE
Implement IsDecorator method

### DIFF
--- a/src/Agents.Net.Tests/MessageDecoratorTest.cs
+++ b/src/Agents.Net.Tests/MessageDecoratorTest.cs
@@ -12,6 +12,38 @@ namespace Agents.Net.Tests
         }
 
         [Test]
+        public void IsDecoratorReturnsTrueForDecorator()
+        {
+            TestMessage message = new TestMessage(Array.Empty<Message>());
+            TestDecorator decorator = new TestDecorator(message);
+
+            Assert.IsTrue(MessageDecorator.IsDecorator(decorator),"TestDecorator.IsDecorator(decorator)");
+        }
+
+        [Test]
+        public void IsDecoratorReturnsTrueForDecoratorIfMessagePassed()
+        {
+            TestMessage message = new TestMessage(Array.Empty<Message>());
+            TestDecorator decorator = new TestDecorator(message);
+
+            Assert.IsTrue(MessageDecorator.IsDecorator(message),"TestDecorator.IsDecorator(message)");
+        }
+
+        [Test]
+        public void IsDecoratorReturnsFalseForNormalMessage()
+        {
+            TestMessage message = new TestMessage(Array.Empty<Message>());
+            
+            Assert.IsFalse(MessageDecorator.IsDecorator(message),"MessageDecorator.IsDecorator(message)");
+        }
+
+        [Test]
+        public void IsDecoratorReturnsThrowsExceptionForNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => MessageDecorator.IsDecorator(null));
+        }
+
+        [Test]
         public void DecoratorAdaptsMessageDomain()
         {
             TestMessage message = new TestMessage(Array.Empty<Message>());

--- a/src/Agents.Net/Agent.cs
+++ b/src/Agents.Net/Agent.cs
@@ -8,7 +8,6 @@
 #endregion
 
 using System;
-using System.Diagnostics.Contracts;
 using System.Runtime.ExceptionServices;
 
 namespace Agents.Net
@@ -27,7 +26,11 @@ namespace Agents.Net
 
         public void Execute(Message messageData)
         {
-            Contract.Requires(messageData != null, nameof(messageData) + " != null");
+            if (messageData == null)
+            {
+                throw new ArgumentNullException(nameof(messageData));
+            }
+
             try
             {
                 ExecuteCore(messageData);

--- a/src/Agents.Net/ConsumableMessage.cs
+++ b/src/Agents.Net/ConsumableMessage.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace Agents.Net
 {

--- a/src/Agents.Net/ExceptionMessage.cs
+++ b/src/Agents.Net/ExceptionMessage.cs
@@ -7,7 +7,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 #endregion
 
-using System;
 using System.Collections.Generic;
 using System.Runtime.ExceptionServices;
 

--- a/src/Agents.Net/InterceptionAction.cs
+++ b/src/Agents.Net/InterceptionAction.cs
@@ -7,10 +7,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 #endregion
 
-using System;
-using System.Collections.Generic;
-using System.Text;
-
 namespace Agents.Net
 {
     public enum InterceptionAction

--- a/src/Agents.Net/InterceptorAgent.cs
+++ b/src/Agents.Net/InterceptorAgent.cs
@@ -8,9 +8,7 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
 using System.Runtime.ExceptionServices;
-using System.Text;
 
 namespace Agents.Net
 {

--- a/src/Agents.Net/InterceptorAgentDefinition.cs
+++ b/src/Agents.Net/InterceptorAgentDefinition.cs
@@ -9,7 +9,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace Agents.Net
 {

--- a/src/Agents.Net/Message.cs
+++ b/src/Agents.Net/Message.cs
@@ -9,7 +9,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.Contracts;
 using System.Linq;
 using System.Threading;
 
@@ -42,7 +41,11 @@ namespace Agents.Net
         
         public void ReplaceWith(Message message)
         {
-            Contract.Requires(message != null, nameof(message) + " != null");
+            if (message == null)
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
+
             message.childMessages.Clear();
             foreach (Message childMessage in childMessages)
             {

--- a/src/Agents.Net/MessageAggregator.cs
+++ b/src/Agents.Net/MessageAggregator.cs
@@ -9,7 +9,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.Contracts;
 using NLog;
 
 namespace Agents.Net
@@ -30,7 +29,11 @@ namespace Agents.Net
 
         public bool TryAggregate(Message message)
         {
-            Contract.Requires(message != null, nameof(message) + " != null");
+            if (message == null)
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
+
             if (!message.Is<T>())
             {
                 return false;
@@ -41,7 +44,11 @@ namespace Agents.Net
 
         public void Aggregate(Message message)
         {
-            Contract.Requires(message != null, nameof(message) + " != null");
+            if (message == null)
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
+
             if (!message.TryGet(out T aggregatedMessage))
             {
                 throw new InvalidOperationException($"Cannot aggregate the message {message}. Aggregated type is {typeof(T)}");

--- a/src/Agents.Net/MessageCollector.cs
+++ b/src/Agents.Net/MessageCollector.cs
@@ -9,7 +9,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.Contracts;
 using System.Linq;
 
 namespace Agents.Net
@@ -30,13 +29,19 @@ namespace Agents.Net
 
         public void Push(Message message)
         {
-            Contract.Requires(message != null, nameof(message) + " != null");
+            if (message == null)
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
             TryPush(message, true);
         }
 
         public bool TryPush(Message message)
         {
-            Contract.Requires(message != null, nameof(message) + " != null");
+            if (message == null)
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
             return TryPush(message, false);
         }
 
@@ -61,7 +66,10 @@ namespace Agents.Net
 
         protected IEnumerable<MessageCollection> GetCompleteSets(MessageDomain domain)
         {
-            Contract.Requires(domain != null, nameof(domain) + " != null");
+            if (domain == null)
+            {
+                throw new ArgumentNullException(nameof(domain));
+            }
             HashSet<MessageCollection> sets = new HashSet<MessageCollection>(new MessageSetIdComparer());
             foreach (MessageDomain messageDomain in ThisAndFlattenedChildren(domain).Where(d => !d.IsTerminated))
             {
@@ -98,7 +106,10 @@ namespace Agents.Net
         protected bool TryGetMessageFittingDomain<T>(MessageDomain domain, Dictionary<MessageDomain, T> messagePool, out T message)
             where T : Message
         {
-            Contract.Requires(messagePool != null, nameof(messagePool) + " != null");
+            if (messagePool == null)
+            {
+                throw new ArgumentNullException(nameof(messagePool));
+            }
             MessageDomain current = domain;
             while (current != null)
             {
@@ -120,7 +131,10 @@ namespace Agents.Net
 
         protected virtual bool Aggregate(Message message, bool throwError)
         {
-            Contract.Requires(message != null, nameof(message) + " != null");
+            if (message == null)
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
             if (message.TryGet(out T1 message1))
             {
                 UpdateMessagePool(message1, Messages1);
@@ -144,8 +158,14 @@ namespace Agents.Net
         protected void UpdateMessagePool<T>(T message, Dictionary<MessageDomain, T> messagePool)
             where T : Message
         {
-            Contract.Requires(message != null, nameof(message) + " != null");
-            Contract.Requires(messagePool != null, nameof(messagePool) + " != null");
+            if (message == null)
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
+            if (messagePool == null)
+            {
+                throw new ArgumentNullException(nameof(messagePool));
+            }
             messagePool[message.MessageDomain] = message;
         }
 
@@ -205,7 +225,10 @@ namespace Agents.Net
 
         protected override bool Aggregate(Message message, bool throwError)
         {
-            Contract.Requires(message != null, nameof(message) + " != null");
+            if (message == null)
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
             if (message.TryGet(out T3 message3))
             {
                 UpdateMessagePool(message3, Messages3);
@@ -257,7 +280,10 @@ namespace Agents.Net
 
         protected override bool Aggregate(Message message, bool throwError)
         {
-            Contract.Requires(message != null, nameof(message) + " != null");
+            if (message == null)
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
             if (message.TryGet(out T4 message4))
             {
                 UpdateMessagePool(message4, Messages4);
@@ -311,7 +337,10 @@ namespace Agents.Net
 
         protected override bool Aggregate(Message message, bool throwError)
         {
-            Contract.Requires(message != null, nameof(message) + " != null");
+            if (message == null)
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
             if (message.TryGet(out T5 message5))
             {
                 UpdateMessagePool(message5, Messages5);
@@ -367,7 +396,10 @@ namespace Agents.Net
 
         protected override bool Aggregate(Message message, bool throwError)
         {
-            Contract.Requires(message != null, nameof(message) + " != null");
+            if (message == null)
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
             if (message.TryGet(out T6 message6))
             {
                 UpdateMessagePool(message6, Messages6);
@@ -425,7 +457,10 @@ namespace Agents.Net
 
         protected override bool Aggregate(Message message, bool throwError)
         {
-            Contract.Requires(message != null, nameof(message) + " != null");
+            if (message == null)
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
             if (message.TryGet(out T7 message7))
             {
                 UpdateMessagePool(message7, Messages7);

--- a/src/Agents.Net/MessageDecorator.cs
+++ b/src/Agents.Net/MessageDecorator.cs
@@ -7,6 +7,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 #endregion
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -20,6 +21,16 @@ namespace Agents.Net
         {
             SwitchDomain(decoratedMessage.MessageDomain);
             AddChild(decoratedMessage.ReplaceHead(this));
+        }
+
+        public static bool IsDecorator(Message message)
+        {
+            if (message == null)
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
+
+            return message.Is<MessageDecorator>();
         }
     }
 }

--- a/src/Agents.Net/MessageDomain.cs
+++ b/src/Agents.Net/MessageDomain.cs
@@ -9,7 +9,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.Contracts;
 using System.Linq;
 
 namespace Agents.Net
@@ -38,7 +37,10 @@ namespace Agents.Net
 
         public static MessageDomainsCreatedMessage CreateNewDomainsFor(IReadOnlyCollection<Message> newDomainRootMessages)
         {
-            Contract.Requires(newDomainRootMessages != null, nameof(newDomainRootMessages) + " != null");
+            if (newDomainRootMessages == null)
+            {
+                throw new ArgumentNullException(nameof(newDomainRootMessages));
+            }
             CreateDomains();
             return new MessageDomainsCreatedMessage(newDomainRootMessages, newDomainRootMessages.SelectMany(m => m.Predecessors).Distinct());
 

--- a/src/Agents.Net/MessageDomainsCreatedMessage.cs
+++ b/src/Agents.Net/MessageDomainsCreatedMessage.cs
@@ -7,9 +7,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 #endregion
 
-using System;
 using System.Collections.Generic;
-using System.Diagnostics.Contracts;
 using System.Linq;
 
 namespace Agents.Net


### PR DESCRIPTION
IsDecorator method is simply a proxy for Is<MessageDecorator>().
This is still useful as the implementation can be change without breaking client code.
Cleanup code contracts, as they are no longer supported. Replaced with tradiotional ArgumentNullException.
This closes #16 