### PR TITLE
Add consumable feature for message collector.

### DIFF
--- a/src/Agents.Net.Tests/MessageCollectorTest.cs
+++ b/src/Agents.Net.Tests/MessageCollectorTest.cs
@@ -1,0 +1,118 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Agents.Net.Tests
+{
+    public class MessageCollectorTest
+    {
+        [Test]
+        public void SetIsExecutedWhenItHasACompleteSet()
+        {
+            bool executed = false;
+            MessageCollector<TestMessage, OtherMessage> collector = 
+                new MessageCollector<TestMessage, OtherMessage>(set =>
+                {
+                    executed = true;
+                });
+            collector.Push(new TestMessage());
+            collector.Push(new OtherMessage());
+
+            executed.Should().BeTrue("set should have been executed.");
+        }
+        
+        [Test]
+        public void SetIsExecutedEachTimeAMessageChanges()
+        {
+            int executed = 0;
+            MessageCollector<TestMessage, OtherMessage> collector = 
+                new MessageCollector<TestMessage, OtherMessage>(set =>
+                {
+                    executed++;
+                });
+            collector.Push(new TestMessage());
+            collector.Push(new OtherMessage());
+            collector.Push(new TestMessage());
+            collector.Push(new OtherMessage());
+
+            executed.Should().Be(3, "each new message should have triggered the collector");
+        }
+        
+        [Test]
+        public void MessagesAreNotRemovedFromCollector()
+        {
+            MessageCollector<TestMessage, OtherMessage> collector = 
+                new MessageCollector<TestMessage, OtherMessage>();
+            collector.Push(new TestMessage());
+            collector.Push(new OtherMessage());
+
+            collector.FindSetsForDomain(MessageDomain.DefaultMessageDomain)
+                .Should().NotBeEmpty("no message was consumed so all messages should still exist.");
+        }
+        
+        [Test]
+        public void ConsumedMessageIsRemovedFromCollector()
+        {
+            MessageCollector<TestMessage, OtherMessage> collector = 
+                new MessageCollector<TestMessage, OtherMessage>(set =>
+                {
+                    set.MarkAsConsumed(set.Message2);
+                });
+            collector.Push(new TestMessage());
+            collector.Push(new OtherMessage());
+
+            collector.FindSetsForDomain(MessageDomain.DefaultMessageDomain)
+                .Should().BeEmpty("no complete set should exist after a message was consumed.");
+        }
+        
+        [Test]
+        public void ConsumedMessageIsRemovedFromCollectorUsingFindSets()
+        {
+            MessageCollector<TestMessage, OtherMessage> collector = 
+                new MessageCollector<TestMessage, OtherMessage>();
+            collector.Push(new TestMessage());
+            collector.Push(new OtherMessage());
+
+            MessageCollection<TestMessage, OtherMessage> set = collector.FindSetsForDomain(MessageDomain.DefaultMessageDomain)
+                .Single();
+            set.MarkAsConsumed(set.Message2);
+
+            collector.FindSetsForDomain(MessageDomain.DefaultMessageDomain)
+                .Should().BeEmpty("no complete set should exist after a message was consumed.");
+        }
+        
+        [Test]
+        public void SetIsExecutedEachTimeAMessageChangesWithConsumedMessage()
+        {
+            int executed = 0;
+            MessageCollector<TestMessage, OtherMessage> collector = 
+                new MessageCollector<TestMessage, OtherMessage>(set =>
+                {
+                    executed++;
+                    set.MarkAsConsumed(set.Message2);
+                });
+            collector.Push(new TestMessage());
+            collector.Push(new OtherMessage());
+            collector.Push(new TestMessage());
+            collector.Push(new OtherMessage());
+
+            executed.Should().Be(2, "only when consumed message is added again, the collector is executed again.");
+        }
+
+        private class OtherMessage : Message
+        {
+
+            public OtherMessage()
+                : base(Array.Empty<Message>())
+            {
+            }
+
+            protected override string DataToString()
+            {
+                return string.Empty;
+            }
+        }
+    }
+}

--- a/src/Agents.Net/MessageCollection.cs
+++ b/src/Agents.Net/MessageCollection.cs
@@ -31,6 +31,8 @@ namespace Agents.Net
             return GetEnumerator();
         }
 
+        public abstract void MarkAsConsumed(Message message);
+
         protected abstract void Dispose(bool disposing);
 
         public void Dispose()
@@ -46,11 +48,13 @@ namespace Agents.Net
     {
         private readonly MessageStore<T1> message1;
         private readonly MessageStore<T2> message2;
+        private readonly MessageCollector<T1, T2> collector;
 
-        public MessageCollection(MessageStore<T1> message1, MessageStore<T2> message2)
+        public MessageCollection(MessageStore<T1> message1, MessageStore<T2> message2, MessageCollector<T1, T2> collector)
         {
             this.message1 = message1;
             this.message2 = message2;
+            this.collector = collector;
         }
 
         public T1 Message1 => message1;
@@ -60,6 +64,11 @@ namespace Agents.Net
         protected override IEnumerable<Message> GetAllMessages()
         {
             return base.GetAllMessages().Concat(new Message[] {Message1, Message2});
+        }
+
+        public override void MarkAsConsumed(Message message)
+        {
+            collector.Remove(message);
         }
 
         protected override void Dispose(bool disposing)
@@ -79,7 +88,8 @@ namespace Agents.Net
     {
         private readonly MessageStore<T3> message3;
 
-        public MessageCollection(MessageStore<T1> message1, MessageStore<T2> message2, MessageStore<T3> message3) : base(message1, message2)
+        public MessageCollection(MessageStore<T1> message1, MessageStore<T2> message2, MessageStore<T3> message3, MessageCollector<T1, T2> collector) 
+            : base(message1, message2, collector)
         {
             this.message3 = message3;
         }
@@ -109,7 +119,8 @@ namespace Agents.Net
     {
         private readonly MessageStore<T4> message4;
 
-        public MessageCollection(MessageStore<T1> message1, MessageStore<T2> message2, MessageStore<T3> message3, MessageStore<T4> message4) : base(message1, message2, message3)
+        public MessageCollection(MessageStore<T1> message1, MessageStore<T2> message2, MessageStore<T3> message3, MessageStore<T4> message4, MessageCollector<T1, T2> collector) 
+            : base(message1, message2, message3, collector)
         {
             this.message4 = message4;
         }
@@ -140,7 +151,8 @@ namespace Agents.Net
     {
         private readonly MessageStore<T5> message5;
 
-        public MessageCollection(MessageStore<T1> message1, MessageStore<T2> message2, MessageStore<T3> message3, MessageStore<T4> message4, MessageStore<T5> message5) : base(message1, message2, message3, message4)
+        public MessageCollection(MessageStore<T1> message1, MessageStore<T2> message2, MessageStore<T3> message3, MessageStore<T4> message4, MessageStore<T5> message5, MessageCollector<T1, T2> collector) 
+            : base(message1, message2, message3, message4, collector)
         {
             this.message5 = message5;
         }
@@ -172,7 +184,8 @@ namespace Agents.Net
     {
         private readonly MessageStore<T6> message6;
 
-        public MessageCollection(MessageStore<T1> message1, MessageStore<T2> message2, MessageStore<T3> message3, MessageStore<T4> message4, MessageStore<T5> message5, MessageStore<T6> message6) : base(message1, message2, message3, message4, message5)
+        public MessageCollection(MessageStore<T1> message1, MessageStore<T2> message2, MessageStore<T3> message3, MessageStore<T4> message4, MessageStore<T5> message5, MessageStore<T6> message6, MessageCollector<T1, T2> collector) 
+            : base(message1, message2, message3, message4, message5, collector)
         {
             this.message6 = message6;
         }
@@ -204,8 +217,8 @@ namespace Agents.Net
         where T7 : Message
     {
         private readonly MessageStore<T7> message7;
-
-        public MessageCollection(MessageStore<T1> message1, MessageStore<T2> message2, MessageStore<T3> message3, MessageStore<T4> message4, MessageStore<T5> message5, MessageStore<T6> message6, MessageStore<T7> message7) : base(message1, message2, message3, message4, message5, message6)
+        public MessageCollection(MessageStore<T1> message1, MessageStore<T2> message2, MessageStore<T3> message3, MessageStore<T4> message4, MessageStore<T5> message5, MessageStore<T6> message6, MessageStore<T7> message7, MessageCollector<T1, T2> collector) 
+            : base(message1, message2, message3, message4, message5, message6, collector)
         {
             this.message7 = message7;
         }

--- a/src/Agents.Net/MessageCollector.cs
+++ b/src/Agents.Net/MessageCollector.cs
@@ -58,6 +58,30 @@ namespace Agents.Net
             return result;
         }
 
+        internal void Remove(Message message)
+        {
+            lock (dictionaryLock)
+            {
+                RemoveMessage(message);
+            }
+        }
+
+        protected virtual void RemoveMessage(Message message)
+        {
+            if (message is T1 message1)
+            {
+                Messages1.Remove(message1.MessageDomain);
+            }
+            else if (message is T2 message2)
+            {
+                Messages2.Remove(message2.MessageDomain);
+            }
+            else
+            {
+                throw new ArgumentException($"There is no message type {message} in this collection.", nameof(message));
+            }
+        }
+
         public IEnumerable<MessageCollection<T1, T2>> FindSetsForDomain(MessageDomain domain)
         {
             IEnumerable<MessageCollection> completedSets = GetCompleteSets(domain);
@@ -96,7 +120,7 @@ namespace Agents.Net
             if (TryGetMessageFittingDomain(domain, Messages1, out MessageStore<T1> message1) &&
                 TryGetMessageFittingDomain(domain, Messages2, out MessageStore<T2> message2))
             {
-                messageCollection = new MessageCollection<T1, T2>(message1, message2);
+                messageCollection = new MessageCollection<T1, T2>(message1, message2, this);
                 return true;
             }
 
@@ -250,12 +274,24 @@ namespace Agents.Net
                 TryGetMessageFittingDomain(domain, Messages2, out MessageStore<T2> message2) &&
                 TryGetMessageFittingDomain(domain, Messages3, out MessageStore<T3> message3))
             {
-                messageCollection = new MessageCollection<T1, T2, T3>(message1, message2, message3);
+                messageCollection = new MessageCollection<T1, T2, T3>(message1, message2, message3, this);
                 return true;
             }
 
             messageCollection = null;
             return false;
+        }
+
+        protected override void RemoveMessage(Message message)
+        {
+            if (message is T3 message3)
+            {
+                Messages3.Remove(message3.MessageDomain);
+            }
+            else
+            {
+                base.RemoveMessage(message);
+            }
         }
 
         public new IEnumerable<MessageCollection<T1, T2, T3>> FindSetsForDomain(MessageDomain domain)
@@ -306,12 +342,24 @@ namespace Agents.Net
                 TryGetMessageFittingDomain(domain, Messages3, out MessageStore<T3> message3) &&
                 TryGetMessageFittingDomain(domain, Messages4, out MessageStore<T4> message4))
             {
-                messageCollection = new MessageCollection<T1, T2, T3, T4>(message1, message2, message3, message4);
+                messageCollection = new MessageCollection<T1, T2, T3, T4>(message1, message2, message3, message4, this);
                 return true;
             }
 
             messageCollection = null;
             return false;
+        }
+
+        protected override void RemoveMessage(Message message)
+        {
+            if (message is T4 message4)
+            {
+                Messages4.Remove(message4.MessageDomain);
+            }
+            else
+            {
+                base.RemoveMessage(message);
+            }
         }
 
         public new IEnumerable<MessageCollection<T1, T2, T3, T4>> FindSetsForDomain(MessageDomain domain)
@@ -364,12 +412,24 @@ namespace Agents.Net
                 TryGetMessageFittingDomain(domain, Messages4, out MessageStore<T4> message4) &&
                 TryGetMessageFittingDomain(domain, Messages5, out MessageStore<T5> message5))
             {
-                messageCollection = new MessageCollection<T1, T2, T3, T4, T5>(message1, message2, message3, message4, message5);
+                messageCollection = new MessageCollection<T1, T2, T3, T4, T5>(message1, message2, message3, message4, message5, this);
                 return true;
             }
 
             messageCollection = null;
             return false;
+        }
+
+        protected override void RemoveMessage(Message message)
+        {
+            if (message is T5 message5)
+            {
+                Messages5.Remove(message5.MessageDomain);
+            }
+            else
+            {
+                base.RemoveMessage(message);
+            }
         }
 
         public new IEnumerable<MessageCollection<T1, T2, T3, T4, T5>> FindSetsForDomain(MessageDomain domain)
@@ -424,12 +484,24 @@ namespace Agents.Net
                 TryGetMessageFittingDomain(domain, Messages5, out MessageStore<T5> message5) &&
                 TryGetMessageFittingDomain(domain, Messages6, out MessageStore<T6> message6))
             {
-                messageCollection = new MessageCollection<T1, T2, T3, T4, T5, T6>(message1, message2, message3, message4, message5, message6);
+                messageCollection = new MessageCollection<T1, T2, T3, T4, T5, T6>(message1, message2, message3, message4, message5, message6, this);
                 return true;
             }
 
             messageCollection = null;
             return false;
+        }
+
+        protected override void RemoveMessage(Message message)
+        {
+            if (message is T3 message6)
+            {
+                Messages6.Remove(message6.MessageDomain);
+            }
+            else
+            {
+                base.RemoveMessage(message);
+            }
         }
 
         public new IEnumerable<MessageCollection<T1, T2, T3, T4, T5, T6>> FindSetsForDomain(MessageDomain domain)
@@ -486,12 +558,24 @@ namespace Agents.Net
                 TryGetMessageFittingDomain(domain, Messages6, out MessageStore<T6> message6) &&
                 TryGetMessageFittingDomain(domain, Messages7, out MessageStore<T7> message7))
             {
-                messageCollection = new MessageCollection<T1, T2, T3, T4, T5, T6, T7>(message1, message2, message3, message4, message5, message6, message7);
+                messageCollection = new MessageCollection<T1, T2, T3, T4, T5, T6, T7>(message1, message2, message3, message4, message5, message6, message7, this);
                 return true;
             }
 
             messageCollection = null;
             return false;
+        }
+
+        protected override void RemoveMessage(Message message)
+        {
+            if (message is T3 message7)
+            {
+                Messages7.Remove(message7.MessageDomain);
+            }
+            else
+            {
+                base.RemoveMessage(message);
+            }
         }
 
         public new IEnumerable<MessageCollection<T1, T2, T3, T4, T5, T6, T7>> FindSetsForDomain(MessageDomain domain)


### PR DESCRIPTION
## Description

Add feature to tell a `MessageCollection` that a message is used up and should not be used again by calling the new method `MarkAsConsumed`

Fixes #47

## How Has This Been Tested?

- MessageCollectorTest

## Checklist:

<!-- To check one of the checkboxes just change [ ] to [x]-->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
- [x] I have added an entry to the [changelog](https://github.com/agents-net/agents.net/blob/master/CHANGELOG.md) if necessary
