### PR TITLE
Make Predecessor property of Message visible.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Changed
 - **Breaking Change:** Switch from magic string based agent definition to type based agent definition
-- **Breaking Change:** Change execution method of aggregator to IReadonlyCollection so that it can be passed directly to TerminateDomainsOf
+- **Breaking Change:** Change execution method of aggregator to `IReadonlyCollection` so that it can be passed directly to TerminateDomainsOf
+- `MessageCollector` messages can know be consumed directly, so that they are removed from the collector
+- `Message` predecessor property visibility changed to public
 
 ### Removed
-- **Breaking Change:** Removed Community class. Register agents directly with IMessageBoard
+- **Breaking Change:** Removed `Community` class. Register agents directly with `IMessageBoard`
 
 ## 2020.6.0
 ### Added
@@ -30,7 +32,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Changed
 - Message domain handling - it is now not dependent on creating specific messages.
-- Renamed IsDecorator to IsDecorated and made it static.
+- Renamed `IsDecorator` to `IsDecorated` and made it static.
 
 ### Fixed
 - #28 - There were several issues which lead to the observed behavior

--- a/src/Agents.Net/Message.cs
+++ b/src/Agents.Net/Message.cs
@@ -78,7 +78,7 @@ namespace Agents.Net
             parent.AddChild(message);
         }
 
-        internal IEnumerable<Message> Predecessors => predecessorMessages;
+        public IEnumerable<Message> Predecessors => predecessorMessages;
 
         internal Message HeadMessage
         {


### PR DESCRIPTION
## Description

Make `Predecessor` property of `Message` visible.

Fixes #48

## How Has This Been Tested?

Only a property. This will not be tested.

## Checklist:

<!-- To check one of the checkboxes just change [ ] to [x]-->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
- [x] I have added an entry to the [changelog](https://github.com/agents-net/agents.net/blob/master/CHANGELOG.md) if necessary
