### PR TITLE
Add interceptor decorator test.

### DIFF
--- a/src/Agents.Net.Tests/Agents.Net.Tests.csproj
+++ b/src/Agents.Net.Tests/Agents.Net.Tests.csproj
@@ -35,4 +35,8 @@
     </Compile>
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="Tools\Communities\DecoratingInterceptorCommunity\" />
+  </ItemGroup>
+
 </Project>

--- a/src/Agents.Net.Tests/Features/CoreUseCases.feature
+++ b/src/Agents.Net.Tests/Features/CoreUseCases.feature
@@ -8,8 +8,6 @@
 	the actual implementation.
 
 	Not Implemented Use Cases:
-	Explicit parallelisation (agents executed parallel; community ran to finish (count executed agents))
-	Message collector collects message from parent and child domain with explicit parallelisation _î
 	Interceptor decorates a message
 	Interceptor replaces a message with a changed value
 	Interceptor delays a message while waiting on a self created message chain
@@ -51,3 +49,15 @@ This scenario shows that all 4 message are executed parallel to each other.
 	Given I have loaded the community "ParallelExecutionCommunity"
 	When I start the message board
 	Then the agent Worker executed 4 messages parallel
+
+Scenario: Decorating interceptor community prints to console
+This scenario shows an use case where a message is intercepted. Based
+on a check of the original message the original message is than decorated.
+Another agent consumes the intercepted message and checks wether is contains
+the decorator or not. If the message is decorated the decorated information
+is displayed too. This shows that interceptors always are executed before
+the acutal consuming agents.
+	Given I have loaded the community "DecoratingInterceptorCommunity"
+	When I start the message board
+	Then the message "Information Detailed" was posted after a while
+	And the program was terminated

--- a/src/Agents.Net.Tests/Features/CoreUseCases.feature.cs
+++ b/src/Agents.Net.Tests/Features/CoreUseCases.feature.cs
@@ -44,8 +44,6 @@ namespace Agents.Net.Tests.Features
 	the actual implementation.
 
 	Not Implemented Use Cases:
-	Explicit parallelisation (agents executed parallel; community ran to finish (count executed agents))
-	Message collector collects message from parent and child domain with explicit parallelisation _î
 	Interceptor decorates a message
 	Interceptor replaces a message with a changed value
 	Interceptor delays a message while waiting on a self created message chain
@@ -98,7 +96,7 @@ namespace Agents.Net.Tests.Features
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Hello World community prints to console", "This scenario shows a simple use case where two agents start simultaneously \r\nwit" +
                     "h the initialization message. They are than collected by another agent and\r\nfina" +
                     "lly printed as message to the console.", tagsOfScenario, argumentsOfScenario);
-#line 20
+#line 18
 this.ScenarioInitialize(scenarioInfo);
 #line hidden
             bool isScenarioIgnored = default(bool);
@@ -118,16 +116,16 @@ this.ScenarioInitialize(scenarioInfo);
             else
             {
                 this.ScenarioStart();
-#line 24
+#line 22
  testRunner.Given("I have loaded the community \"HelloWorldCommunity\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
 #line hidden
-#line 25
+#line 23
  testRunner.When("I start the message board", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-#line 26
+#line 24
  testRunner.Then("the message \"Hello World\" was posted after a while", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
-#line 27
+#line 25
  testRunner.And("the program was terminated", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
             }
@@ -143,7 +141,7 @@ this.ScenarioInitialize(scenarioInfo);
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Hello World community executes agents parallel", "This scenario shows that the HelloAgent and the WorldAgent are executed\r\nparallel" +
                     ", although it was not specified this way. It is simply coincidence\r\nthat the req" +
                     "uirements (InitializeMessage) of both agents are satisfied at\r\nthe same time.", tagsOfScenario, argumentsOfScenario);
-#line 29
+#line 27
 this.ScenarioInitialize(scenarioInfo);
 #line hidden
             bool isScenarioIgnored = default(bool);
@@ -163,13 +161,13 @@ this.ScenarioInitialize(scenarioInfo);
             else
             {
                 this.ScenarioStart();
-#line 34
+#line 32
  testRunner.Given("I have loaded the community \"HelloWorldCommunity\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
 #line hidden
-#line 35
+#line 33
  testRunner.When("I start the message board", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-#line 36
+#line 34
  testRunner.Then("the agents HelloAgent, WorldAgent were executed parallel", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
             }
@@ -187,7 +185,7 @@ the same kind. Once these messages are all executed the result is aggregated
 and printed to the console. Additionally, this scenario shows, that the message
 collector can collect message across message domains as each of the 4 messages
 gets a new domain.", tagsOfScenario, argumentsOfScenario);
-#line 38
+#line 36
 this.ScenarioInitialize(scenarioInfo);
 #line hidden
             bool isScenarioIgnored = default(bool);
@@ -207,16 +205,16 @@ this.ScenarioInitialize(scenarioInfo);
             else
             {
                 this.ScenarioStart();
-#line 44
+#line 42
  testRunner.Given("I have loaded the community \"ParallelExecutionCommunity\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
 #line hidden
-#line 45
+#line 43
  testRunner.When("I start the message board", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-#line 46
+#line 44
  testRunner.Then("the message \"10\" was posted after a while", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
-#line 47
+#line 45
  testRunner.And("the program was terminated", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
             }
@@ -230,7 +228,7 @@ this.ScenarioInitialize(scenarioInfo);
             string[] tagsOfScenario = ((string[])(null));
             System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Parallel execution community executes in parallel", "This scenario shows that all 4 message are executed parallel to each other.", tagsOfScenario, argumentsOfScenario);
-#line 49
+#line 47
 this.ScenarioInitialize(scenarioInfo);
 #line hidden
             bool isScenarioIgnored = default(bool);
@@ -250,14 +248,61 @@ this.ScenarioInitialize(scenarioInfo);
             else
             {
                 this.ScenarioStart();
-#line 51
+#line 49
  testRunner.Given("I have loaded the community \"ParallelExecutionCommunity\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
 #line hidden
-#line 52
+#line 50
  testRunner.When("I start the message board", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-#line 53
+#line 51
  testRunner.Then("the agent Worker executed 4 messages parallel", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line hidden
+            }
+            this.ScenarioCleanup();
+        }
+        
+        [NUnit.Framework.TestAttribute()]
+        [NUnit.Framework.DescriptionAttribute("Decorating interceptor community prints to console")]
+        public virtual void DecoratingInterceptorCommunityPrintsToConsole()
+        {
+            string[] tagsOfScenario = ((string[])(null));
+            System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Decorating interceptor community prints to console", @"This scenario shows an use case where one agent produces 4 messages of
+the same kind. Once these messages are all executed the result is aggregated
+and printed to the console. Additionally, this scenario shows, that the message
+collector can collect message across message domains as each of the 4 messages
+gets a new domain.", tagsOfScenario, argumentsOfScenario);
+#line 53
+this.ScenarioInitialize(scenarioInfo);
+#line hidden
+            bool isScenarioIgnored = default(bool);
+            bool isFeatureIgnored = default(bool);
+            if ((tagsOfScenario != null))
+            {
+                isScenarioIgnored = tagsOfScenario.Where(__entry => __entry != null).Where(__entry => String.Equals(__entry, "ignore", StringComparison.CurrentCultureIgnoreCase)).Any();
+            }
+            if ((this._featureTags != null))
+            {
+                isFeatureIgnored = this._featureTags.Where(__entry => __entry != null).Where(__entry => String.Equals(__entry, "ignore", StringComparison.CurrentCultureIgnoreCase)).Any();
+            }
+            if ((isScenarioIgnored || isFeatureIgnored))
+            {
+                testRunner.SkipScenario();
+            }
+            else
+            {
+                this.ScenarioStart();
+#line 59
+ testRunner.Given("I have loaded the community \"DecoratingInterceptorCommunity\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
+#line hidden
+#line 60
+ testRunner.When("I start the message board", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+#line 61
+ testRunner.Then("the message \"Information Detailed\" was posted after a while", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line hidden
+#line 62
+ testRunner.And("the program was terminated", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
             }
             this.ScenarioCleanup();

--- a/src/Agents.Net.Tests/Tools/Communities/DecoratingInterceptorCommunity/Agents/InformationBroker.cs
+++ b/src/Agents.Net.Tests/Tools/Communities/DecoratingInterceptorCommunity/Agents/InformationBroker.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using Agents.Net;
+using Agents.Net.Tests.Tools.Communities.DecoratingInterceptorCommunity.Messages;
+
+namespace Agents.Net.Tests.Tools.Communities.DecoratingInterceptorCommunity.Agents
+{
+    [Consumes(typeof(InitializeMessage))]
+    [Produces(typeof(InformationGathered))]
+    public class InformationBroker : Agent
+    {
+        public InformationBroker(IMessageBoard messageBoard) : base(messageBoard)
+        {
+        }
+
+        protected override void ExecuteCore(Message messageData)
+        {
+            OnMessage(new InformationGathered("Information", true, messageData));
+        }
+    }
+}

--- a/src/Agents.Net.Tests/Tools/Communities/DecoratingInterceptorCommunity/Agents/InformationDecorator.cs
+++ b/src/Agents.Net.Tests/Tools/Communities/DecoratingInterceptorCommunity/Agents/InformationDecorator.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using Agents.Net;
+using Agents.Net.Tests.Tools.Communities.DecoratingInterceptorCommunity.Messages;
+
+namespace Agents.Net.Tests.Tools.Communities.DecoratingInterceptorCommunity.Agents
+{
+    [Produces(typeof(DetailedInformationGathered))]
+    [Intercepts(typeof(InformationGathered))]
+    public class InformationDecorator : InterceptorAgent
+    {
+        public InformationDecorator(IMessageBoard messageBoard) : base(messageBoard)
+        {
+        }
+
+        protected override InterceptionAction InterceptCore(Message messageData)
+        {
+            InformationGathered gathered = messageData.Get<InformationGathered>();
+            if (gathered.AdditionalDataAvailable)
+            {
+                DetailedInformationGathered.Decorate(gathered, "Detailed");
+            }
+
+            return InterceptionAction.Continue;
+        }
+    }
+}

--- a/src/Agents.Net.Tests/Tools/Communities/DecoratingInterceptorCommunity/Agents/InformationMessageGenerator.cs
+++ b/src/Agents.Net.Tests/Tools/Communities/DecoratingInterceptorCommunity/Agents/InformationMessageGenerator.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using Agents.Net;
+using Agents.Net.Tests.Tools.Communities.DecoratingInterceptorCommunity.Messages;
+
+namespace Agents.Net.Tests.Tools.Communities.DecoratingInterceptorCommunity.Agents
+{
+    [Consumes(typeof(InformationGathered))]
+    [Consumes(typeof(DetailedInformationGathered), Implicitly = true)]
+    [Produces(typeof(DisplayMessageGenerated))]
+    public class InformationMessageGenerator : Agent
+    {
+        public InformationMessageGenerator(IMessageBoard messageBoard) : base(messageBoard)
+        {
+        }
+
+        protected override void ExecuteCore(Message messageData)
+        {
+            InformationGathered information = messageData.Get<InformationGathered>();
+            string informationMessage = information.Information;
+            if (messageData.TryGet(out DetailedInformationGathered detailedInformation))
+            {
+                informationMessage += $" {detailedInformation.DetailedInformation}";
+            }
+            OnMessage(new DisplayMessageGenerated(informationMessage, messageData));
+        }
+    }
+}

--- a/src/Agents.Net.Tests/Tools/Communities/DecoratingInterceptorCommunity/Agents/MessageConsoleWriter.cs
+++ b/src/Agents.Net.Tests/Tools/Communities/DecoratingInterceptorCommunity/Agents/MessageConsoleWriter.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using Agents.Net;
+using Agents.Net.Tests.Tools.Communities.DecoratingInterceptorCommunity.Messages;
+
+namespace Agents.Net.Tests.Tools.Communities.DecoratingInterceptorCommunity.Agents
+{
+    [Consumes(typeof(DisplayMessageGenerated))]
+    public class MessageConsoleWriter : Agent
+    {
+        private readonly IConsole console;
+        private readonly Action terminateAction;
+
+        public MessageConsoleWriter(IMessageBoard messageBoard, IConsole console, Action terminateAction) : base(messageBoard)
+        {
+            this.console = console;
+            this.terminateAction = terminateAction;
+        }
+
+        protected override void ExecuteCore(Message messageData)
+        {
+            DisplayMessageGenerated messageGenerated = messageData.Get<DisplayMessageGenerated>();
+            console.WriteLine(messageGenerated.DisplayMessage);
+            terminateAction();
+        }
+    }
+}

--- a/src/Agents.Net.Tests/Tools/Communities/DecoratingInterceptorCommunity/DecoratingInterceptorCommunityModule.cs
+++ b/src/Agents.Net.Tests/Tools/Communities/DecoratingInterceptorCommunity/DecoratingInterceptorCommunityModule.cs
@@ -1,0 +1,16 @@
+﻿using Autofac;
+using Agents.Net;
+
+namespace Agents.Net.Tests.Tools.Communities.DecoratingInterceptorCommunity
+{
+    public class DecoratingInterceptorCommunityModule : Module
+    {
+        protected override void Load(ContainerBuilder builder)
+        {
+            builder.RegisterType<Agents.InformationMessageGenerator>().As<Agent>().InstancePerLifetimeScope();
+            builder.RegisterType<Agents.InformationBroker>().As<Agent>().InstancePerLifetimeScope();
+            builder.RegisterType<Agents.MessageConsoleWriter>().As<Agent>().InstancePerLifetimeScope();
+            builder.RegisterType<Agents.InformationDecorator>().As<Agent>().InstancePerLifetimeScope();
+        }
+    }
+}

--- a/src/Agents.Net.Tests/Tools/Communities/DecoratingInterceptorCommunity/Messages/DetailedInformationGathered.cs
+++ b/src/Agents.Net.Tests/Tools/Communities/DecoratingInterceptorCommunity/Messages/DetailedInformationGathered.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Generic;
+using Agents.Net;
+
+namespace Agents.Net.Tests.Tools.Communities.DecoratingInterceptorCommunity.Messages
+{
+    public class DetailedInformationGathered : MessageDecorator
+    {
+        private DetailedInformationGathered(Message decoratedMessage, string detailedInformation, IEnumerable<Message> additionalPredecessors = null)
+            : base(decoratedMessage, additionalPredecessors)
+        {
+            DetailedInformation = detailedInformation;
+        }
+
+        public static DetailedInformationGathered Decorate(InformationGathered decoratedMessage, string detailedInformation,
+                                          IEnumerable<Message> additionalPredecessors = null)
+        {
+            return new DetailedInformationGathered(decoratedMessage, detailedInformation, additionalPredecessors);
+        }
+
+        public string DetailedInformation { get; }
+
+        protected override string DataToString()
+        {
+            return $"{nameof(DetailedInformation)}: {DetailedInformation}";
+        }
+    }
+}

--- a/src/Agents.Net.Tests/Tools/Communities/DecoratingInterceptorCommunity/Messages/DisplayMessageGenerated.cs
+++ b/src/Agents.Net.Tests/Tools/Communities/DecoratingInterceptorCommunity/Messages/DisplayMessageGenerated.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+using Agents.Net;
+
+namespace Agents.Net.Tests.Tools.Communities.DecoratingInterceptorCommunity.Messages
+{
+    public class DisplayMessageGenerated : Message
+    {
+        public DisplayMessageGenerated(string displayMessage, Message predecessorMessage,
+                                       params Message[] childMessages)
+			: base(predecessorMessage, childMessages:childMessages)
+        {
+            DisplayMessage = displayMessage;
+        }
+
+        public DisplayMessageGenerated(string displayMessage, IEnumerable<Message> predecessorMessages,
+                                       params Message[] childMessages)
+			: base(predecessorMessages, childMessages:childMessages)
+        {
+            DisplayMessage = displayMessage;
+        }
+
+        public string DisplayMessage { get; }
+
+        protected override string DataToString()
+        {
+            return $"{nameof(DisplayMessage)}: {DisplayMessage}";
+        }
+    }
+}

--- a/src/Agents.Net.Tests/Tools/Communities/DecoratingInterceptorCommunity/Messages/InformationGathered.cs
+++ b/src/Agents.Net.Tests/Tools/Communities/DecoratingInterceptorCommunity/Messages/InformationGathered.cs
@@ -1,0 +1,33 @@
+﻿using System.Collections.Generic;
+using Agents.Net;
+
+namespace Agents.Net.Tests.Tools.Communities.DecoratingInterceptorCommunity.Messages
+{
+    public class InformationGathered : Message
+    {
+        public InformationGathered(string information, bool additionalDataAvailable, Message predecessorMessage,
+                                   params Message[] childMessages)
+			: base(predecessorMessage, childMessages:childMessages)
+        {
+            Information = information;
+            AdditionalDataAvailable = additionalDataAvailable;
+        }
+
+        public InformationGathered(string information, bool additionalDataAvailable,
+                                   IEnumerable<Message> predecessorMessages, params Message[] childMessages)
+			: base(predecessorMessages, childMessages:childMessages)
+        {
+            Information = information;
+            AdditionalDataAvailable = additionalDataAvailable;
+        }
+
+        public string Information { get; }
+
+        public bool AdditionalDataAvailable { get; }
+
+        protected override string DataToString()
+        {
+            return $"{nameof(Information)}: {Information}; {nameof(AdditionalDataAvailable)}: {AdditionalDataAvailable}";
+        }
+    }
+}

--- a/src/Agents.Net.Tests/Tools/Communities/DecoratingInterceptorCommunity/Model.amodel
+++ b/src/Agents.Net.Tests/Tools/Communities/DecoratingInterceptorCommunity/Model.amodel
@@ -1,0 +1,98 @@
+{
+  "GeneratorSettings": {
+    "PackageNamespace": "Agents.Net.Tests.Tools.Communities.DecoratingInterceptorCommunity",
+    "GenerateAutofacModule": true
+  },
+  "Agents": [
+    {
+      "Id": "781e90bd-3e95-4f0d-9283-e718c4423c6f",
+      "Name": "InformationBroker",
+      "Namespace": ".Agents",
+      "ConsumingMessages": [
+        "682c5a0b-b0c3-4899-b981-f654d50ccf0f"
+      ],
+      "ProducedMessages": [
+        "4a06311f-ac86-4e00-a6b8-91d5ffa0eeb6"
+      ],
+      "IncomingEvents": [],
+      "ProducedEvents": []
+    },
+    {
+      "$type": "Agents.Net.Designer.Model.InterceptorAgentModel, Agents.Net.Designer",
+      "InterceptingMessages": [
+        "4a06311f-ac86-4e00-a6b8-91d5ffa0eeb6"
+      ],
+      "Id": "60f9ceb7-1b62-421d-8165-e8092373639a",
+      "Name": "InformationDecorator",
+      "Namespace": ".Agents",
+      "ConsumingMessages": [],
+      "ProducedMessages": [
+        "51e160f8-1ba6-4453-96d6-c0f946887731"
+      ],
+      "IncomingEvents": [],
+      "ProducedEvents": []
+    },
+    {
+      "Id": "486019af-8ac4-40ad-aaba-840eae1876d6",
+      "Name": "InformationMessageGenerator",
+      "Namespace": ".Agents",
+      "ConsumingMessages": [
+        "4a06311f-ac86-4e00-a6b8-91d5ffa0eeb6",
+        "51e160f8-1ba6-4453-96d6-c0f946887731"
+      ],
+      "ProducedMessages": [
+        "e51a0204-7732-4c98-9220-6d79a969f54e"
+      ],
+      "IncomingEvents": [],
+      "ProducedEvents": []
+    },
+    {
+      "Id": "5b72b5c1-72d9-458a-b7bd-52c1711028e6",
+      "Name": "MessageConsoleWriter",
+      "Namespace": ".Agents",
+      "ConsumingMessages": [
+        "e51a0204-7732-4c98-9220-6d79a969f54e"
+      ],
+      "ProducedMessages": [],
+      "IncomingEvents": [],
+      "ProducedEvents": [
+        "Display Message On Console",
+        "Terminate Program"
+      ]
+    }
+  ],
+  "Messages": [
+    {
+      "Id": "682c5a0b-b0c3-4899-b981-f654d50ccf0f",
+      "Name": "InitializeMessage",
+      "Namespace": "Agents.Net",
+      "BuildIn": true
+    },
+    {
+      "Id": "b2a937dc-2d04-411f-ac76-9f3a0cda45df",
+      "Name": "ExceptionMessage",
+      "Namespace": "Agents.Net",
+      "BuildIn": true
+    },
+    {
+      "Id": "4a06311f-ac86-4e00-a6b8-91d5ffa0eeb6",
+      "Name": "InformationGathered",
+      "Namespace": ".Messages",
+      "BuildIn": false
+    },
+    {
+      "$type": "Agents.Net.Designer.Model.MessageDecoratorModel, Agents.Net.Designer",
+      "DecoratedMessage": "4a06311f-ac86-4e00-a6b8-91d5ffa0eeb6",
+      "Id": "51e160f8-1ba6-4453-96d6-c0f946887731",
+      "Name": "DetailedInformationGathered",
+      "Namespace": ".Messages",
+      "BuildIn": false
+    },
+    {
+      "Id": "e51a0204-7732-4c98-9220-6d79a969f54e",
+      "Name": "DisplayMessageGenerated",
+      "Namespace": ".Messages",
+      "BuildIn": false
+    }
+  ]
+}

--- a/src/Agents.Net.Tests/Tools/Communities/DecoratingInterceptorCommunity/Model.svg
+++ b/src/Agents.Net.Tests/Tools/Communities/DecoratingInterceptorCommunity/Model.svg
@@ -1,0 +1,56 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--SvgWriter version 0.0.0.0-->
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="747.22333333333" height="515.8125" id="svg2" version="1.1" xmlns="http://www.w3.org/2000/svg">
+  <g transform="translate(126.99333333333334,1015.8125000000002)">
+    <!--Edges-->
+    <path fill="none" stroke="#008000" stroke-opacity="1" stroke-width="1" d="M 135 -989.4125 L 135 -967.725" />
+    <polygon stroke="#008000" stroke-opacity="1" stroke-width="1" fill="#008000" fill-opacity="1" points="132.78305336833 -967.725 135 -957.725 137.21694663167 -967.725" />
+    <path fill="none" stroke="#0000ff" stroke-opacity="1" stroke-width="1" d="M 30.38708456936 -800.20034238243 L 83.39861000188 -772.57176610666" />
+    <polygon stroke="#0000ff" stroke-opacity="1" stroke-width="1" fill="#0000ff" fill-opacity="1" points="82.37398912162 -770.60580465754 92.26648900733 -767.95 84.42323088213 -774.53772755578" />
+    <path fill="none" stroke="#008000" stroke-opacity="1" stroke-width="1" d="M 186 -638.975 L 186 -617.2875" />
+    <polygon stroke="#008000" stroke-opacity="1" stroke-width="1" fill="#008000" fill-opacity="1" points="183.78305336833 -617.2875 186 -607.2875 188.21694663167 -617.2875" />
+    <path fill="none" stroke="#0000ff" stroke-opacity="1" stroke-width="1" d="M 135 -924.925 L 135 -903.2375" />
+    <polygon stroke="#0000ff" stroke-opacity="1" stroke-width="1" fill="#0000ff" fill-opacity="1" points="132.78305336833 -903.2375 135 -893.2375 137.21694663167 -903.2375" />
+    <path fill="none" stroke="#ff0000" stroke-opacity="1" stroke-width="1" d="M 106.65589503577 -872.90143252236 L 99.5 -869.8375 C76.9601373546 -860.18662923352 55.4784926788 -849.29613170265 35.05506597261 -837.16600740738" />
+    <polygon stroke="#ff0000" stroke-opacity="1" stroke-width="1" fill="#ff0000" fill-opacity="1" points="107.52850018943 -870.8634402227 115.84868421053 -876.8375 105.78328988212 -874.93942482202" />
+    <polygon stroke="#ff0000" stroke-opacity="1" stroke-width="1" fill="#ff0000" fill-opacity="1" points="33.91238680094 -839.06578020387 26.48574468469 -832.01171476295 36.19774514428 -835.26623461088" />
+    <text x="64" y="-849.8375" font-family="Times-Roman" font-size="12" fill="#000000">intercepted</text>
+    <path fill="none" stroke="#008000" stroke-opacity="1" stroke-width="1" d="M 151.99342105263 -876.8375 L 166.5 -869.8375 C187.5 -859.70416666667 198 -834.815625 198 -795.171875 C198 -764.84861922361 196.82987516611 -742.97829649206 194.48962549832 -729.56090680537" />
+    <polygon stroke="#008000" stroke-opacity="1" stroke-width="1" fill="#008000" fill-opacity="1" points="192.3370262883 -730.09116052645 192.09780553523 -719.85115926673 196.64222470833 -729.0306530843" />
+    <path fill="none" stroke="#d88b8b" stroke-opacity="1" stroke-width="1" d="M 117.20821419288 -767.95 L 121.5 -771.771875 C130.5 -779.78645833333 135 -800.66770833333 135 -834.415625 L 135 -866.8375" />
+    <polygon stroke="#d88b8b" stroke-opacity="1" stroke-width="1" fill="#d88b8b" fill-opacity="1" points="137.21694663167 -866.8375 135 -876.8375 132.78305336833 -866.8375" />
+    <text x="135" y="-811.2375" font-family="Times-Roman" font-size="12" fill="#000000">decorates</text>
+    <path fill="none" stroke="#008000" stroke-opacity="1" stroke-width="1" d="M 119.36309127249 -751.55 L 155.37988314202 -725.55903625184" />
+    <polygon stroke="#008000" stroke-opacity="1" stroke-width="1" fill="#008000" fill-opacity="1" points="154.08257616875 -723.7613024048 163.488936474 -719.70726266949 156.67719011529 -727.35677009888" />
+    <path fill="none" stroke="#0000ff" stroke-opacity="1" stroke-width="1" d="M 186 -687.0625 L 186 -665.375" />
+    <polygon stroke="#0000ff" stroke-opacity="1" stroke-width="1" fill="#0000ff" fill-opacity="1" points="183.78305336833 -665.375 186 -655.375 188.21694663167 -665.375" />
+    <path fill="none" stroke="#ffa500" stroke-opacity="1" stroke-width="1" d="M 245.90515845219 -576.52640741381 L 397.79162439438 -540.11459153111" />
+    <polygon stroke="#ffa500" stroke-opacity="1" stroke-width="1" fill="#ffa500" fill-opacity="1" points="397.27479842609 -537.95872899231 407.51609185786 -537.78334024653 398.30845036267 -542.2704540699" />
+    <path fill="none" stroke="#ffa500" stroke-opacity="1" stroke-width="1" d="M 186 -574.4875 L 186 -552.8" />
+    <polygon stroke="#ffa500" stroke-opacity="1" stroke-width="1" fill="#ffa500" fill-opacity="1" points="183.78305336833 -552.8 186 -542.8 188.21694663167 -552.8" />
+    <!--nodes-->
+    <rect fill="#ffffff" fill-opacity="1" stroke="#000000" stroke-opacity="1" stroke-width="1" x="88.91166666667" y="-1005.8125" width="92.17666666667" height="16.4" rx="3" ry="3" />
+    <text x="89.91166666667" y="-992.8125" font-family="Times-Roman" font-size="12" fill="#000000">InitializeMessage</text>
+    <ellipse fill="#fafad2" fill-opacity="1" stroke="#000000" stroke-opacity="1" stroke-width="1" cx="0" cy="-816.0375" rx="116.99333333333" ry="16.4" />
+    <text x="-57.49666666667" y="-811.2375" font-family="Times-Roman" font-size="12" fill="#000000">InformationDecorator</text>
+    <rect fill="#ffffff" fill-opacity="1" stroke="#000000" stroke-opacity="1" stroke-width="1" x="-26.96666666667" y="-534.6" width="99.93333333333" height="16.4" rx="3" ry="3" />
+    <text x="-25.96666666667" y="-521.6" font-family="Times-Roman" font-size="12" fill="#000000">ExceptionMessage</text>
+    <rect fill="#ffffff" fill-opacity="1" stroke="#000000" stroke-opacity="1" stroke-width="1" x="114.87833333333" y="-655.375" width="142.24333333333" height="16.4" rx="3" ry="3" />
+    <text x="115.87833333333" y="-642.375" font-family="Times-Roman" font-size="12" fill="#000000">DisplayMessageGenerated</text>
+    <ellipse fill="#ffffff" fill-opacity="1" stroke="#000000" stroke-opacity="1" stroke-width="1" cx="135" cy="-941.325" rx="98.67666666667" ry="16.4" />
+    <text x="86.66166666667" y="-936.525" font-family="Times-Roman" font-size="12" fill="#000000">InformationBroker</text>
+    <rect fill="#ffffff" fill-opacity="1" stroke="#000000" stroke-opacity="1" stroke-width="1" x="78.415" y="-893.2375" width="113.17" height="16.4" rx="3" ry="3" />
+    <text x="79.415" y="-880.2375" font-family="Times-Roman" font-size="12" fill="#000000">InformationGathered</text>
+    <rect fill="#fafad2" fill-opacity="1" stroke="#000000" stroke-opacity="1" stroke-width="1" x="29.405" y="-767.95" width="157.19" height="16.4" rx="3" ry="3" />
+    <text x="30.405" y="-754.95" font-family="Times-Roman" font-size="12" fill="#000000">DetailedInformationGathered</text>
+    <ellipse fill="#ffffff" fill-opacity="1" stroke="#000000" stroke-opacity="1" stroke-width="1" cx="186" cy="-703.4625" rx="163.99666666667" ry="16.4" />
+    <text x="105.00166666667" y="-698.6625" font-family="Times-Roman" font-size="12" fill="#000000">InformationMessageGenerator</text>
+    <polygon stroke="#000000" stroke-opacity="1" stroke-width="1" fill="#808080" fill-opacity="1" points="299.77 -526.4 455 -510 610.23 -526.4 455 -542.8" />
+    <text x="378.385" y="-521.6" font-family="Times-Roman" font-size="12" fill="#000000">Display Message On Console</text>
+    <polygon stroke="#000000" stroke-opacity="1" stroke-width="1" fill="#808080" fill-opacity="1" points="83.05666666667 -526.4 186 -510 288.94333333333 -526.4 186 -542.8" />
+    <text x="135.52833333333" y="-521.6" font-family="Times-Roman" font-size="12" fill="#000000">Terminate Program</text>
+    <ellipse fill="#ffffff" fill-opacity="1" stroke="#000000" stroke-opacity="1" stroke-width="1" cx="186" cy="-590.8875" rx="124.05333333333" ry="16.4" />
+    <text x="124.97333333333" y="-586.0875" font-family="Times-Roman" font-size="12" fill="#000000">MessageConsoleWriter</text>
+    <!--end of nodes-->
+  </g>
+</svg>

--- a/src/Agents.Net.Tests/Tools/Communities/HelloWorldCommunity/Model.amodel
+++ b/src/Agents.Net.Tests/Tools/Communities/HelloWorldCommunity/Model.amodel
@@ -5,61 +5,84 @@
   },
   "Agents": [
     {
+      "Id": "2e9c3d11-ae1b-45b8-bd64-b0d029bedd27",
       "Name": "HelloAgent",
       "Namespace": ".Agents",
       "ConsumingMessages": [
-        "InitializeMessage"
+        "71f3cd60-e583-431e-a091-2ab6fac97f21"
       ],
       "ProducedMessages": [
-        "HelloConsoleMessage"
-      ]
+        "f780b81f-f9d9-41df-9525-44738fd6ed83"
+      ],
+      "IncomingEvents": [],
+      "ProducedEvents": []
     },
     {
+      "Id": "6e6e2a5a-a492-41e7-a139-92850cd8a818",
       "Name": "WorldAgent",
       "Namespace": ".Agents",
       "ConsumingMessages": [
-        "InitializeMessage"
+        "71f3cd60-e583-431e-a091-2ab6fac97f21"
       ],
       "ProducedMessages": [
-        "WorldConsoleMessage"
-      ]
+        "f4a80468-3fc0-4799-908c-d17baf6f08f7"
+      ],
+      "IncomingEvents": [],
+      "ProducedEvents": []
     },
     {
+      "Id": "95990613-0722-403f-b910-723d35753ba1",
       "Name": "ConsoleMessageJoiner",
       "Namespace": ".Agents",
       "ConsumingMessages": [
-        "WorldConsoleMessage",
-        "HelloConsoleMessage"
+        "f4a80468-3fc0-4799-908c-d17baf6f08f7",
+        "f780b81f-f9d9-41df-9525-44738fd6ed83"
       ],
       "ProducedMessages": [
-        "ConsoleMessageCreated"
-      ]
+        "94b6391b-7518-434f-9e50-0c34fbc5c8e3"
+      ],
+      "IncomingEvents": [],
+      "ProducedEvents": []
     },
     {
+      "Id": "35bfcf55-c5d0-49e1-ad21-44316a108a72",
       "Name": "ConsoleMessageDisplayAgent",
       "Namespace": ".Agents",
       "ConsumingMessages": [
-        "ConsoleMessageCreated"
+        "94b6391b-7518-434f-9e50-0c34fbc5c8e3"
       ],
       "ProducedMessages": [],
+      "IncomingEvents": [],
       "ProducedEvents": [
-        "TerminateProgram",
-        "DisplayMessageOnConsole"
+        "Terminate Program",
+        "Display Message On Console"
       ]
     }
   ],
   "Messages": [
     {
+      "Id": "71f3cd60-e583-431e-a091-2ab6fac97f21",
+      "Name": "InitializeMessage",
+      "Namespace": "Agents.Net",
+      "BuildIn": true
+    },
+    {
+      "Id": "f780b81f-f9d9-41df-9525-44738fd6ed83",
       "Name": "HelloConsoleMessage",
-      "Namespace": ".Messages"
+      "Namespace": ".Messages",
+      "BuildIn": false
     },
     {
+      "Id": "f4a80468-3fc0-4799-908c-d17baf6f08f7",
       "Name": "WorldConsoleMessage",
-      "Namespace": ".Messages"
+      "Namespace": ".Messages",
+      "BuildIn": false
     },
     {
+      "Id": "94b6391b-7518-434f-9e50-0c34fbc5c8e3",
       "Name": "ConsoleMessageCreated",
-      "Namespace": ".Messages"
+      "Namespace": ".Messages",
+      "BuildIn": false
     }
   ]
 }

--- a/src/Agents.Net.Tests/Tools/Communities/ParallelExecutionCommunity/Model.amodel
+++ b/src/Agents.Net.Tests/Tools/Communities/ParallelExecutionCommunity/Model.amodel
@@ -5,75 +5,46 @@
   },
   "Agents": [
     {
-      "Name": "WorkScheduler",
-      "Namespace": ".Agents",
-      "ConsumingMessages": [
-        "InitializeMessage"
-      ],
-      "ProducedMessages": [
-        "WorkScheduled"
-      ]
-    },
-    {
+      "Id": "2739e646-2b90-43ce-b2d0-d5fa0da90cf4",
       "Name": "InformationBroker",
       "Namespace": ".Agents",
       "ConsumingMessages": [
-        "InitializeMessage"
-      ],
-      "ProducedMessages": [
-        "InformationGathered"
-      ]
-    },
-    {
-      "Name": "Worker",
-      "Namespace": ".Agents",
-      "ConsumingMessages": [
-        "InformationGathered",
-        "WorkScheduled"
-      ],
-      "ProducedMessages": [
-        "WorkDone"
-      ]
-    },
-    {
-      "Name": "WorkDoneAggregator",
-      "Namespace": ".Agents",
-      "ConsumingMessages": [
-        "WorkDone"
-      ],
-      "ProducedMessages": [
-        "WorkloadFinished"
-      ]
-    },
-    {
-      "Name": "ResultReporter",
-      "Namespace": ".Agents",
-      "ConsumingMessages": [
-        "WorkloadFinished"
+        "ae869fc7-0489-4bd9-b398-6af28bdf3e14"
       ],
       "ProducedMessages": [],
-      "ProducedEvents": [
-        "Terminate Program",
-        "Report to Console"
-      ]
+      "IncomingEvents": [],
+      "ProducedEvents": []
+    },
+    {
+      "Id": "7fa36e25-1971-46c9-931e-ed8e6f99ee97",
+      "Name": "WorkScheduler",
+      "Namespace": ".Agents",
+      "ConsumingMessages": [
+        "ae869fc7-0489-4bd9-b398-6af28bdf3e14"
+      ],
+      "ProducedMessages": [],
+      "IncomingEvents": [],
+      "ProducedEvents": []
     }
   ],
   "Messages": [
     {
-      "Name": "WorkScheduled",
-      "Namespace": ".Messages"
+      "Id": "ae869fc7-0489-4bd9-b398-6af28bdf3e14",
+      "Name": "InitializeMessage",
+      "Namespace": "Agents.Net",
+      "BuildIn": true
     },
     {
+      "Id": "ef8573fd-772f-4d65-a74e-7b1b778462a2",
+      "Name": "ExceptionMessage",
+      "Namespace": "Agents.Net",
+      "BuildIn": true
+    },
+    {
+      "Id": "28a45d71-4311-461a-9446-c44a57c08c4e",
       "Name": "InformationGathered",
-      "Namespace": ".Messages"
-    },
-    {
-      "Name": "WorkDone",
-      "Namespace": ".Messages"
-    },
-    {
-      "Name": "WorkloadFinished",
-      "Namespace": ".Messages"
+      "Namespace": ".Messages",
+      "BuildIn": false
     }
   ]
 }


### PR DESCRIPTION
## Description

Add a single new core use case for the usage of interceptors to decorate messages.

## How Has This Been Tested?

CoreUseCasesFeature.DecoratingInterceptorCommunityPrintsToConsole

## Checklist:

<!-- To check one of the checkboxes just change [ ] to [x]-->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
- [x] I have added an entry to the [changelog](https://github.com/agents-net/agents.net/blob/master/CHANGELOG.md) if necessary
