### PR TITLE
Count whole message stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - Integration tests
 - Community health files and appropriate readme
 - It is now possible to register to all messages by using the type Message for the ConsumeAttribute or InterceptsAttribute
+- Messages have now a defined lifecycle. This can be used to dispose objects during execution safely
 
 ### Changed
 - **Breaking Change:** Switch from magic string based agent definition to type based agent definition

--- a/src/Agents.Net.Tests/Features/MessageBoardUseCases.feature
+++ b/src/Agents.Net.Tests/Features/MessageBoardUseCases.feature
@@ -15,3 +15,18 @@ InitializeMessage). Once they have send their messages the program terminates.
 	When I start the message board
 	Then the message "Consumed: 6; Intercepted: 6" was posted after a while
 	And the program was terminated
+	
+@DisposeCheck
+Scenario: Dispose messages after they were used
+This scenario shows the feature, that messages are disposed after they were
+used. The heuristic that is used to determine whether a message is used or not
+is complex as the agents themself cannot determine that as they do not know 
+how many agents react to the message. The heuristic used to determine when a 
+message can be disposed is that by default after the Execute method of any
+Agent the message will count it as used. After it was used as many times as
+there are agents it will dispose itself. The community used will have different
+messages. Afterwards it is checked whether all messages are disposed 
+	Given I have loaded the community "DefaultDisposeCommunity"
+	When I start the message board
+	Then the program was terminated
+	And all messages are disposed

--- a/src/Agents.Net.Tests/Features/MessageBoardUseCases.feature.cs
+++ b/src/Agents.Net.Tests/Features/MessageBoardUseCases.feature.cs
@@ -127,12 +127,10 @@ this.ScenarioInitialize(scenarioInfo);
         [NUnit.Framework.TestAttribute()]
         [NUnit.Framework.DescriptionAttribute("Dispose messages after they were used")]
         [NUnit.Framework.CategoryAttribute("DisposeCheck")]
-        [NUnit.Framework.CategoryAttribute("Slow")]
         public virtual void DisposeMessagesAfterTheyWereUsed()
         {
             string[] tagsOfScenario = new string[] {
-                    "DisposeCheck",
-                    "Slow"};
+                    "DisposeCheck"};
             System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Dispose messages after they were used", @"This scenario shows the feature, that messages are disposed after they were
 used. The heuristic that is used to determine whether a message is used or not
@@ -142,7 +140,7 @@ message can be disposed is that by default after the Execute method of any
 Agent the message will count it as used. After it was used as many times as
 there are agents it will dispose itself. The community used will have different
 messages. Afterwards it is checked whether all messages are disposed ", tagsOfScenario, argumentsOfScenario);
-#line 21
+#line 20
 this.ScenarioInitialize(scenarioInfo);
 #line hidden
             bool isScenarioIgnored = default(bool);
@@ -162,16 +160,16 @@ this.ScenarioInitialize(scenarioInfo);
             else
             {
                 this.ScenarioStart();
-#line 30
+#line 29
  testRunner.Given("I have loaded the community \"DefaultDisposeCommunity\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
 #line hidden
-#line 31
+#line 30
  testRunner.When("I start the message board", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-#line 32
+#line 31
  testRunner.Then("the program was terminated", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
-#line 33
+#line 32
  testRunner.And("all messages are disposed", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
             }

--- a/src/Agents.Net.Tests/Features/MessageBoardUseCases.feature.cs
+++ b/src/Agents.Net.Tests/Features/MessageBoardUseCases.feature.cs
@@ -123,6 +123,60 @@ this.ScenarioInitialize(scenarioInfo);
             }
             this.ScenarioCleanup();
         }
+        
+        [NUnit.Framework.TestAttribute()]
+        [NUnit.Framework.DescriptionAttribute("Dispose messages after they were used")]
+        [NUnit.Framework.CategoryAttribute("DisposeCheck")]
+        [NUnit.Framework.CategoryAttribute("Slow")]
+        public virtual void DisposeMessagesAfterTheyWereUsed()
+        {
+            string[] tagsOfScenario = new string[] {
+                    "DisposeCheck",
+                    "Slow"};
+            System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Dispose messages after they were used", @"This scenario shows the feature, that messages are disposed after they were
+used. The heuristic that is used to determine whether a message is used or not
+is complex as the agents themself cannot determine that as they do not know 
+how many agents react to the message. The heuristic used to determine when a 
+message can be disposed is that by default after the Execute method of any
+Agent the message will count it as used. After it was used as many times as
+there are agents it will dispose itself. The community used will have different
+messages. Afterwards it is checked whether all messages are disposed ", tagsOfScenario, argumentsOfScenario);
+#line 21
+this.ScenarioInitialize(scenarioInfo);
+#line hidden
+            bool isScenarioIgnored = default(bool);
+            bool isFeatureIgnored = default(bool);
+            if ((tagsOfScenario != null))
+            {
+                isScenarioIgnored = tagsOfScenario.Where(__entry => __entry != null).Where(__entry => String.Equals(__entry, "ignore", StringComparison.CurrentCultureIgnoreCase)).Any();
+            }
+            if ((this._featureTags != null))
+            {
+                isFeatureIgnored = this._featureTags.Where(__entry => __entry != null).Where(__entry => String.Equals(__entry, "ignore", StringComparison.CurrentCultureIgnoreCase)).Any();
+            }
+            if ((isScenarioIgnored || isFeatureIgnored))
+            {
+                testRunner.SkipScenario();
+            }
+            else
+            {
+                this.ScenarioStart();
+#line 30
+ testRunner.Given("I have loaded the community \"DefaultDisposeCommunity\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
+#line hidden
+#line 31
+ testRunner.When("I start the message board", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+#line 32
+ testRunner.Then("the program was terminated", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line hidden
+#line 33
+ testRunner.And("all messages are disposed", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+            }
+            this.ScenarioCleanup();
+        }
     }
 }
 #pragma warning restore

--- a/src/Agents.Net.Tests/SpecFlow/IntegrationTestStepDefinitions.Given.cs
+++ b/src/Agents.Net.Tests/SpecFlow/IntegrationTestStepDefinitions.Given.cs
@@ -64,12 +64,21 @@ namespace Agents.Net.Tests.SpecFlow
             builder.RegisterModule((IModule) Activator.CreateInstance(moduleType));
             builder.RegisterType<MessageBoard>().As<IMessageBoard>().InstancePerLifetimeScope();
             builder.RegisterType<WaitingConsole>().As<IConsole>().AsSelf().InstancePerLifetimeScope();
+            if (context.ScenarioInfo.Tags.Contains("DisposeCheck"))
+            {
+                builder.RegisterType<DisposeManager>().AsSelf().As<Agent>().InstancePerLifetimeScope();
+            }
             builder.RegisterInstance((Action) Terminate);
             if (context.TryGetValue(out CommandLineArgs args))
             {
                 builder.RegisterInstance(args);
             }
             IContainer container = builder.Build();
+            
+            if (context.ScenarioInfo.Tags.Contains("DisposeCheck"))
+            {
+                context.Set(container.Resolve<DisposeManager>());
+            }
             return container;
 
             void Terminate()

--- a/src/Agents.Net.Tests/SpecFlow/IntegrationTestStepDefinitions.Then.cs
+++ b/src/Agents.Net.Tests/SpecFlow/IntegrationTestStepDefinitions.Then.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using Agents.Net.Tests.Tools;
 using FluentAssertions;
@@ -20,15 +21,22 @@ namespace Agents.Net.Tests.SpecFlow
         [Then("the program was terminated")]
         public void ThenTheProgramWasTerminated()
         {
-            context.Get<ManualResetEventSlim>(TerminateEventKey).Wait(100)
+            context.Get<ManualResetEventSlim>(TerminateEventKey).Wait(300)
                    .Should().BeTrue("program should have been terminated.");
         }        
         
         [Then(@"the program was not terminated")]
         public void ThenTheProgramWasNotTerminated()
         {
-            context.Get<ManualResetEventSlim>(TerminateEventKey).Wait(100)
+            context.Get<ManualResetEventSlim>(TerminateEventKey).Wait(300)
                    .Should().BeFalse("program should not have been terminated.");
+        }    
+        
+        [Then(@"all messages are disposed")]
+        public void ThenAllMessagesAreDisposed()
+        {
+            context.Get<WaitingConsole>().WaitForMessages(out _);
+            context.Get<DisposeManager>().CheckAllDisposed();
         }
 
         [Then("the agents (.*) were executed parallel")]

--- a/src/Agents.Net.Tests/Tools/Communities/DefaultDisposeCommunity/Agents/ConsumingAgent1.cs
+++ b/src/Agents.Net.Tests/Tools/Communities/DefaultDisposeCommunity/Agents/ConsumingAgent1.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Threading;
+using Agents.Net;
+using Agents.Net.Tests.Tools.Communities.DefaultDisposeCommunity.Messages;
+using FluentAssertions;
+
+namespace Agents.Net.Tests.Tools.Communities.DefaultDisposeCommunity.Agents
+{
+    [Consumes(typeof(SingleConsumedMessage))]
+    [Consumes(typeof(MultiConsumedMessage))]
+    [Consumes(typeof(DecoratingMessage))]
+    [Produces(typeof(AllMessagesConsumed))]
+    public class ConsumingAgent1 : Agent
+    {
+        public ConsumingAgent1(IMessageBoard messageBoard) : base(messageBoard)
+        {
+        }
+
+        private int counter;
+
+        protected override void ExecuteCore(Message messageData)
+        {
+            if (messageData is DisposableMessage disposableMessage)
+            {
+                //This timeout ensures that the issue https://github.com/agents-net/agents.net/issues/68 is checked
+                Thread.Sleep(10);
+                disposableMessage.IsDisposed.Should().BeFalse("messages should not be disposed before used.");
+            }
+            if (Interlocked.Increment(ref counter) == 3)
+            {
+                OnMessage(new AllMessagesConsumed(messageData));
+            }
+        }
+    }
+}

--- a/src/Agents.Net.Tests/Tools/Communities/DefaultDisposeCommunity/Agents/ConsumingAgent2.cs
+++ b/src/Agents.Net.Tests/Tools/Communities/DefaultDisposeCommunity/Agents/ConsumingAgent2.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Threading;
+using Agents.Net;
+using Agents.Net.Tests.Tools.Communities.DefaultDisposeCommunity.Messages;
+using FluentAssertions;
+
+namespace Agents.Net.Tests.Tools.Communities.DefaultDisposeCommunity.Agents
+{
+    [Consumes(typeof(MultiConsumedMessage))]
+    public class ConsumingAgent2 : Agent
+    {
+        public ConsumingAgent2(IMessageBoard messageBoard) : base(messageBoard)
+        {
+        }
+
+        protected override void ExecuteCore(Message messageData)
+        {
+            if (messageData is DisposableMessage disposableMessage)
+            {
+                //This timeout ensures that the issue https://github.com/agents-net/agents.net/issues/68 is checked
+                Thread.Sleep(10);
+                disposableMessage.IsDisposed.Should().BeFalse("messages should not be disposed before used.");
+            }
+        }
+    }
+}

--- a/src/Agents.Net.Tests/Tools/Communities/DefaultDisposeCommunity/Agents/InterceptorDecorator.cs
+++ b/src/Agents.Net.Tests/Tools/Communities/DefaultDisposeCommunity/Agents/InterceptorDecorator.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Threading;
+using Agents.Net;
+using Agents.Net.Tests.Tools.Communities.DefaultDisposeCommunity.Messages;
+using FluentAssertions;
+
+namespace Agents.Net.Tests.Tools.Communities.DefaultDisposeCommunity.Agents
+{
+    [Produces(typeof(DecoratingMessage))]
+    [Intercepts(typeof(InterceptedMessage))]
+    [Intercepts(typeof(DecoratedMessage))]
+    public class InterceptorDecorator : InterceptorAgent
+    {
+        public InterceptorDecorator(IMessageBoard messageBoard) : base(messageBoard)
+        {
+        }
+
+        protected override InterceptionAction InterceptCore(Message messageData)
+        {
+            if (messageData is DisposableMessage disposableMessage)
+            {
+                //This timeout ensures that the issue https://github.com/agents-net/agents.net/issues/68 is checked
+                Thread.Sleep(10);
+                disposableMessage.IsDisposed.Should().BeFalse("messages should not be disposed before used.");
+            }
+            if (messageData.TryGet(out DecoratedMessage decoratedMessage))
+            {
+                DecoratingMessage.Decorate(decoratedMessage);
+                return InterceptionAction.Continue;
+            }
+
+            return InterceptionAction.DoNotPublish;
+        }
+    }
+}

--- a/src/Agents.Net.Tests/Tools/Communities/DefaultDisposeCommunity/Agents/MessageGenerator.cs
+++ b/src/Agents.Net.Tests/Tools/Communities/DefaultDisposeCommunity/Agents/MessageGenerator.cs
@@ -1,0 +1,28 @@
+using System;
+using Agents.Net;
+using Agents.Net.Tests.Tools.Communities.DefaultDisposeCommunity.Messages;
+
+namespace Agents.Net.Tests.Tools.Communities.DefaultDisposeCommunity.Agents
+{
+    [Consumes(typeof(InitializeMessage))]
+    [Produces(typeof(SingleConsumedMessage))]
+    [Produces(typeof(MultiConsumedMessage))]
+    [Produces(typeof(UnconsumedMessage))]
+    [Produces(typeof(InterceptedMessage))]
+    [Produces(typeof(DecoratedMessage))]
+    public class MessageGenerator : Agent
+    {
+        public MessageGenerator(IMessageBoard messageBoard) : base(messageBoard)
+        {
+        }
+
+        protected override void ExecuteCore(Message messageData)
+        {
+            OnMessage(new SingleConsumedMessage(messageData));
+            OnMessage(new MultiConsumedMessage(messageData));
+            OnMessage(new UnconsumedMessage(messageData));
+            OnMessage(new InterceptedMessage(messageData));
+            OnMessage(new DecoratedMessage(messageData));
+        }
+    }
+}

--- a/src/Agents.Net.Tests/Tools/Communities/DefaultDisposeCommunity/Agents/Terminator.cs
+++ b/src/Agents.Net.Tests/Tools/Communities/DefaultDisposeCommunity/Agents/Terminator.cs
@@ -1,0 +1,22 @@
+using System;
+using Agents.Net;
+using Agents.Net.Tests.Tools.Communities.DefaultDisposeCommunity.Messages;
+
+namespace Agents.Net.Tests.Tools.Communities.DefaultDisposeCommunity.Agents
+{
+    [Consumes(typeof(AllMessagesConsumed))]
+    public class Terminator : Agent
+    {
+        private readonly Action terminateAction;
+        
+        public Terminator(IMessageBoard messageBoard, Action terminateAction) : base(messageBoard)
+        {
+            this.terminateAction = terminateAction;
+        }
+
+        protected override void ExecuteCore(Message messageData)
+        {
+            terminateAction();
+        }
+    }
+}

--- a/src/Agents.Net.Tests/Tools/Communities/DefaultDisposeCommunity/DefaultDisposeCommunityModule.cs
+++ b/src/Agents.Net.Tests/Tools/Communities/DefaultDisposeCommunity/DefaultDisposeCommunityModule.cs
@@ -1,0 +1,17 @@
+using Autofac;
+using Agents.Net;
+
+namespace Agents.Net.Tests.Tools.Communities.DefaultDisposeCommunity
+{
+    public class DefaultDisposeCommunityModule : Module
+    {
+        protected override void Load(ContainerBuilder builder)
+        {
+            builder.RegisterType<Agents.ConsumingAgent2>().As<Agent>().InstancePerLifetimeScope();
+            builder.RegisterType<Agents.ConsumingAgent1>().As<Agent>().InstancePerLifetimeScope();
+            builder.RegisterType<Agents.InterceptorDecorator>().As<Agent>().InstancePerLifetimeScope();
+            builder.RegisterType<Agents.MessageGenerator>().As<Agent>().InstancePerLifetimeScope();
+            builder.RegisterType<Agents.Terminator>().As<Agent>().InstancePerLifetimeScope();
+        }
+    }
+}

--- a/src/Agents.Net.Tests/Tools/Communities/DefaultDisposeCommunity/Messages/AllMessagesConsumed.cs
+++ b/src/Agents.Net.Tests/Tools/Communities/DefaultDisposeCommunity/Messages/AllMessagesConsumed.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using Agents.Net;
+
+namespace Agents.Net.Tests.Tools.Communities.DefaultDisposeCommunity.Messages
+{
+    public class AllMessagesConsumed : DisposableMessage
+    {
+        public AllMessagesConsumed(Message predecessorMessage, params Message[] childMessages)
+			: base(predecessorMessage, childMessages:childMessages)
+        {
+        }
+
+        public AllMessagesConsumed(IEnumerable<Message> predecessorMessages, params Message[] childMessages)
+			: base(predecessorMessages, childMessages:childMessages)
+        {
+        }
+
+        protected override string DataToString()
+        {
+            return string.Empty;
+        }
+    }
+}

--- a/src/Agents.Net.Tests/Tools/Communities/DefaultDisposeCommunity/Messages/DecoratedMessage.cs
+++ b/src/Agents.Net.Tests/Tools/Communities/DefaultDisposeCommunity/Messages/DecoratedMessage.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using Agents.Net;
+
+namespace Agents.Net.Tests.Tools.Communities.DefaultDisposeCommunity.Messages
+{
+    public class DecoratedMessage : DisposableMessage
+    {
+        public DecoratedMessage(Message predecessorMessage, params Message[] childMessages)
+			: base(predecessorMessage, childMessages:childMessages)
+        {
+        }
+
+        public DecoratedMessage(IEnumerable<Message> predecessorMessages, params Message[] childMessages)
+			: base(predecessorMessages, childMessages:childMessages)
+        {
+        }
+
+        protected override string DataToString()
+        {
+            return string.Empty;
+        }
+    }
+}

--- a/src/Agents.Net.Tests/Tools/Communities/DefaultDisposeCommunity/Messages/DecoratingMessage.cs
+++ b/src/Agents.Net.Tests/Tools/Communities/DefaultDisposeCommunity/Messages/DecoratingMessage.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using Agents.Net;
+
+namespace Agents.Net.Tests.Tools.Communities.DefaultDisposeCommunity.Messages
+{
+    public class DecoratingMessage : MessageDecorator
+    {
+        private DecoratingMessage(Message decoratedMessage, IEnumerable<Message> additionalPredecessors = null)
+            : base(decoratedMessage, additionalPredecessors)
+        {
+        }
+
+        public static DecoratingMessage Decorate(DecoratedMessage decoratedMessage,
+                                          IEnumerable<Message> additionalPredecessors = null)
+        {
+            return new DecoratingMessage(decoratedMessage, additionalPredecessors);
+        }
+
+        protected override string DataToString()
+        {
+            return string.Empty;
+        }
+    }
+}

--- a/src/Agents.Net.Tests/Tools/Communities/DefaultDisposeCommunity/Messages/InterceptedMessage.cs
+++ b/src/Agents.Net.Tests/Tools/Communities/DefaultDisposeCommunity/Messages/InterceptedMessage.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using Agents.Net;
+
+namespace Agents.Net.Tests.Tools.Communities.DefaultDisposeCommunity.Messages
+{
+    public class InterceptedMessage : DisposableMessage
+    {
+        public InterceptedMessage(Message predecessorMessage, params Message[] childMessages)
+			: base(predecessorMessage, childMessages:childMessages)
+        {
+        }
+
+        public InterceptedMessage(IEnumerable<Message> predecessorMessages, params Message[] childMessages)
+			: base(predecessorMessages, childMessages:childMessages)
+        {
+        }
+
+        protected override string DataToString()
+        {
+            return string.Empty;
+        }
+    }
+}

--- a/src/Agents.Net.Tests/Tools/Communities/DefaultDisposeCommunity/Messages/MultiConsumedMessage.cs
+++ b/src/Agents.Net.Tests/Tools/Communities/DefaultDisposeCommunity/Messages/MultiConsumedMessage.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using Agents.Net;
+
+namespace Agents.Net.Tests.Tools.Communities.DefaultDisposeCommunity.Messages
+{
+    public class MultiConsumedMessage : DisposableMessage
+    {
+        public MultiConsumedMessage(Message predecessorMessage, params Message[] childMessages)
+			: base(predecessorMessage, childMessages:childMessages)
+        {
+        }
+
+        public MultiConsumedMessage(IEnumerable<Message> predecessorMessages, params Message[] childMessages)
+			: base(predecessorMessages, childMessages:childMessages)
+        {
+        }
+
+        protected override string DataToString()
+        {
+            return string.Empty;
+        }
+    }
+}

--- a/src/Agents.Net.Tests/Tools/Communities/DefaultDisposeCommunity/Messages/SingleConsumedMessage.cs
+++ b/src/Agents.Net.Tests/Tools/Communities/DefaultDisposeCommunity/Messages/SingleConsumedMessage.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using Agents.Net;
+
+namespace Agents.Net.Tests.Tools.Communities.DefaultDisposeCommunity.Messages
+{
+    public class SingleConsumedMessage : DisposableMessage
+    {
+        public SingleConsumedMessage(Message predecessorMessage, params Message[] childMessages)
+			: base(predecessorMessage, childMessages:childMessages)
+        {
+        }
+
+        public SingleConsumedMessage(IEnumerable<Message> predecessorMessages, params Message[] childMessages)
+			: base(predecessorMessages, childMessages:childMessages)
+        {
+        }
+
+        protected override string DataToString()
+        {
+            return string.Empty;
+        }
+    }
+}

--- a/src/Agents.Net.Tests/Tools/Communities/DefaultDisposeCommunity/Messages/UnconsumedMessage.cs
+++ b/src/Agents.Net.Tests/Tools/Communities/DefaultDisposeCommunity/Messages/UnconsumedMessage.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using Agents.Net;
+
+namespace Agents.Net.Tests.Tools.Communities.DefaultDisposeCommunity.Messages
+{
+    public class UnconsumedMessage : DisposableMessage
+    {
+        public UnconsumedMessage(Message predecessorMessage, params Message[] childMessages)
+			: base(predecessorMessage, childMessages:childMessages)
+        {
+        }
+
+        public UnconsumedMessage(IEnumerable<Message> predecessorMessages, params Message[] childMessages)
+			: base(predecessorMessages, childMessages:childMessages)
+        {
+        }
+
+        protected override string DataToString()
+        {
+            return string.Empty;
+        }
+    }
+}

--- a/src/Agents.Net.Tests/Tools/Communities/DefaultDisposeCommunity/Model.amodel
+++ b/src/Agents.Net.Tests/Tools/Communities/DefaultDisposeCommunity/Model.amodel
@@ -1,0 +1,141 @@
+{
+  "GeneratorSettings": {
+    "PackageNamespace": "Agents.Net.Tests.Tools.Communities.DefaultDisposeCommunity",
+    "GenerateAutofacModule": true
+  },
+  "Agents": [
+    {
+      "Id": "7dfdfe91-9e7a-42ec-9fff-a107be4cd152",
+      "Name": "MessageGenerator",
+      "Namespace": ".Agents",
+      "ConsumingMessages": [
+        "38ec9bc7-0433-4b28-927e-1dc5463dfdad"
+      ],
+      "ProducedMessages": [
+        "1e12352c-eb86-4c14-a7a1-3dacae9e19a9",
+        "38ce4772-5e7c-46c3-bb8b-f172b3670552",
+        "479fe122-9b96-4bc2-9b73-310453126c67",
+        "efc1145f-bdac-44bb-9908-0345d7133846",
+        "7f3350b5-1dd6-40b4-838e-aa25b56a8a74"
+      ],
+      "IncomingEvents": [],
+      "ProducedEvents": []
+    },
+    {
+      "Id": "eafdd7dd-23fa-4696-b464-a83134ba85ef",
+      "Name": "ConsumingAgent1",
+      "Namespace": ".Agents",
+      "ConsumingMessages": [
+        "1e12352c-eb86-4c14-a7a1-3dacae9e19a9",
+        "38ce4772-5e7c-46c3-bb8b-f172b3670552",
+        "efc1145f-bdac-44bb-9908-0345d7133846",
+        "45ad0038-4ce9-4f39-99aa-854bbcb9992c"
+      ],
+      "ProducedMessages": [
+        "8dac8906-eb69-4d44-8939-032c95abb82f"
+      ],
+      "IncomingEvents": [],
+      "ProducedEvents": []
+    },
+    {
+      "Id": "6530266c-73f2-48b7-8e17-b19c40acbc5c",
+      "Name": "ConsumingAgent2",
+      "Namespace": ".Agents",
+      "ConsumingMessages": [
+        "38ce4772-5e7c-46c3-bb8b-f172b3670552"
+      ],
+      "ProducedMessages": [],
+      "IncomingEvents": [],
+      "ProducedEvents": [
+        "NOP"
+      ]
+    },
+    {
+      "$type": "Agents.Net.Designer.Model.InterceptorAgentModel, Agents.Net.Designer.Model",
+      "InterceptingMessages": [
+        "efc1145f-bdac-44bb-9908-0345d7133846",
+        "7f3350b5-1dd6-40b4-838e-aa25b56a8a74"
+      ],
+      "Id": "2112e69f-0963-4a72-a3dc-c16bd2058ddb",
+      "Name": "InterceptorDecorator",
+      "Namespace": ".Agents",
+      "ConsumingMessages": [],
+      "ProducedMessages": [
+        "45ad0038-4ce9-4f39-99aa-854bbcb9992c"
+      ],
+      "IncomingEvents": [],
+      "ProducedEvents": []
+    },
+    {
+      "Id": "73697a4c-7982-4f4b-8c7d-4cafa6290175",
+      "Name": "Terminator",
+      "Namespace": ".Agents",
+      "ConsumingMessages": [
+        "8dac8906-eb69-4d44-8939-032c95abb82f"
+      ],
+      "ProducedMessages": [],
+      "IncomingEvents": [],
+      "ProducedEvents": [
+        "Terminate Program"
+      ]
+    }
+  ],
+  "Messages": [
+    {
+      "Id": "38ec9bc7-0433-4b28-927e-1dc5463dfdad",
+      "Name": "InitializeMessage",
+      "Namespace": "Agents.Net",
+      "BuildIn": true
+    },
+    {
+      "Id": "a170bf76-0054-4c44-b3c3-9cac02fd8dbc",
+      "Name": "ExceptionMessage",
+      "Namespace": "Agents.Net",
+      "BuildIn": true
+    },
+    {
+      "Id": "1e12352c-eb86-4c14-a7a1-3dacae9e19a9",
+      "Name": "SingleConsumedMessage",
+      "Namespace": ".Messages",
+      "BuildIn": false
+    },
+    {
+      "Id": "38ce4772-5e7c-46c3-bb8b-f172b3670552",
+      "Name": "MultiConsumedMessage",
+      "Namespace": ".Messages",
+      "BuildIn": false
+    },
+    {
+      "Id": "479fe122-9b96-4bc2-9b73-310453126c67",
+      "Name": "UnconsumedMessage",
+      "Namespace": ".Messages",
+      "BuildIn": false
+    },
+    {
+      "Id": "efc1145f-bdac-44bb-9908-0345d7133846",
+      "Name": "InterceptedMessage",
+      "Namespace": ".Messages",
+      "BuildIn": false
+    },
+    {
+      "Id": "7f3350b5-1dd6-40b4-838e-aa25b56a8a74",
+      "Name": "DecoratedMessage",
+      "Namespace": ".Messages",
+      "BuildIn": false
+    },
+    {
+      "$type": "Agents.Net.Designer.Model.MessageDecoratorModel, Agents.Net.Designer.Model",
+      "DecoratedMessage": "7f3350b5-1dd6-40b4-838e-aa25b56a8a74",
+      "Id": "45ad0038-4ce9-4f39-99aa-854bbcb9992c",
+      "Name": "DecoratingMessage",
+      "Namespace": ".Messages",
+      "BuildIn": false
+    },
+    {
+      "Id": "8dac8906-eb69-4d44-8939-032c95abb82f",
+      "Name": "AllMessagesConsumed",
+      "Namespace": ".Messages",
+      "BuildIn": false
+    }
+  ]
+}

--- a/src/Agents.Net.Tests/Tools/DisposableMessage.cs
+++ b/src/Agents.Net.Tests/Tools/DisposableMessage.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+
+namespace Agents.Net.Tests.Tools
+{
+    public abstract class DisposableMessage : Message
+    {
+        protected DisposableMessage(Message predecessorMessage, string name = null, params Message[] childMessages) : base(predecessorMessage, name, childMessages)
+        {
+        }
+
+        protected DisposableMessage(IEnumerable<Message> predecessorMessages, string name = null, params Message[] childMessages) : base(predecessorMessages, name, childMessages)
+        {
+        }
+        
+        public bool IsDisposed { get; set; }
+
+        protected override void Dispose(bool disposing)
+        {
+            IsDisposed = disposing;
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/src/Agents.Net.Tests/Tools/DisposeManager.cs
+++ b/src/Agents.Net.Tests/Tools/DisposeManager.cs
@@ -1,0 +1,28 @@
+using System.Collections.Concurrent;
+using FluentAssertions;
+
+namespace Agents.Net.Tests.Tools
+{
+    [Consumes(typeof(Message))]
+    public class DisposeManager : Agent
+    {
+        public DisposeManager(IMessageBoard messageBoard) : base(messageBoard)
+        {
+        }
+        
+        private readonly ConcurrentBag<DisposableMessage> messages = new ConcurrentBag<DisposableMessage>();
+
+        public void CheckAllDisposed()
+        {
+            messages.Should().OnlyContain(message => message.IsDisposed);
+        }
+
+        protected override void ExecuteCore(Message messageData)
+        {
+            if (messageData.TryGet(out DisposableMessage disposableMessage))
+            {
+                messages.Add(disposableMessage);
+            }
+        }
+    }
+}

--- a/src/Agents.Net.Tests/Tools/ExecutionOrder.cs
+++ b/src/Agents.Net.Tests/Tools/ExecutionOrder.cs
@@ -33,7 +33,7 @@ namespace Agents.Net.Tests.Tools
 
                     activeStep?.Collect(activeAgents[log.Agent]);
                 }
-                else
+                else if(activeAgents.ContainsKey(log.Agent))
                 {
                     AgentCollector remainingCollector = activeAgents[log.Agent].Finish(log.Message);
                     if (remainingCollector == null)

--- a/src/Agents.Net/Message.cs
+++ b/src/Agents.Net/Message.cs
@@ -259,12 +259,21 @@ namespace Agents.Net
             return !Equals(left, right);
         }
 
-        internal void Used()
+        internal void Used(bool propagate = false)
         {
             if (Interlocked.Decrement(ref remainingUses) == 0)
             {
                 Dispose();
             }
+
+            if (propagate)
+            {
+                foreach (Message child in Children)
+                {
+                    child.Used();
+                }
+            }
+            
         }
 
         public IDisposable DelayDispose()
@@ -286,6 +295,7 @@ namespace Agents.Net
 
         protected virtual void Dispose(bool disposing)
         {
+            remainingUses = 0;
         }
 
         public void Dispose()


### PR DESCRIPTION
## Description

This change changes the behavior how the message guesses when it can dispose itself. The new behavior marks the whole stack of messages (meaning including all decorators) as used and waits until all messages of the stack are used up before disposing the whole stack of messages.

Fixes #68

## How Has This Been Tested?

- Agents.Net.Tests.Features.MessageBoardUseCasesFeature.DisposeMessagesAfterTheyWereUsed

## Checklist:

<!-- To check one of the checkboxes just change [ ] to [x]-->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
- [x] I have added an entry to the [changelog](https://github.com/agents-net/agents.net/blob/master/CHANGELOG.md) if necessary
