### PR TITLE
Fix versioning for nuget action.

### DIFF
--- a/src/Agents.Net/Agents.Net.csproj
+++ b/src/Agents.Net/Agents.Net.csproj
@@ -42,5 +42,6 @@
   </ItemGroup>
   
   <Import Project="..\_Build_\CodeAnalysis.targets" Condition="Exists('..\_Build_\CodeAnalysis.targets')" />
+  <Import Project=".\NugetVersion.targets" Condition="Exists('.\NugetVersion.targets') and '$(Configuration)'=='Release'" />
 
 </Project>

--- a/src/Agents.Net/NugetVersion.targets
+++ b/src/Agents.Net/NugetVersion.targets
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+	<Version>2021.0.0</Version>
+  </PropertyGroup>
+ 
+</Project>

--- a/src/Agents.Net/NugetVersion.xml
+++ b/src/Agents.Net/NugetVersion.xml
@@ -1,1 +1,0 @@
-<Version>2021.0.0</Version>


### PR DESCRIPTION
## Description

Fixes an issue that the nuget version published did not use the NugetVersion file inside the Agents.Net Project directory.

## How Has This Been Tested?

Manually

## Checklist:

<!-- To check one of the checkboxes just change [ ] to [x]-->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
- [x] I have added an entry to the [changelog](https://github.com/agents-net/agents.net/blob/master/CHANGELOG.md) if necessary
