### PR TITLE
Terminate all domains automatically with message aggregator.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 -->
 
 ## [Unreleased]
+### Changed
+- MessageAggregator automatically terminates the message domains of the aggregated messages. Can be disabled with optional constructor paramter.
 
 ## 2021.0.0
 ### Added

--- a/src/Agents.Net.Tests/MessageAggregatorTest.cs
+++ b/src/Agents.Net.Tests/MessageAggregatorTest.cs
@@ -1,0 +1,144 @@
+using FluentAssertions;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Agents.Net.Tests
+{
+    public class MessageAggregatorTest
+    {
+        [Test]
+        public void AggregateSingleMessage()
+        {
+            bool executed = false;
+            MessageAggregator<TestMessage> aggregator =
+                new MessageAggregator<TestMessage>(set =>
+               {
+                   executed = true;
+               });
+
+            aggregator.Aggregate(new TestMessage());
+
+            executed.Should().BeTrue("A message in the default domain should be executed immediately.");
+        }
+
+        [Test]
+        public void AggregateMultipleMessagesInDifferentDomains()
+        {
+            bool executed = false;
+            MessageAggregator<TestMessage> aggregator =
+                new MessageAggregator<TestMessage>(set =>
+                {
+                    executed = true;
+                });
+
+            TestMessage[] messages = new[] { new TestMessage(), new TestMessage(), new TestMessage() };
+            MessageDomain.CreateNewDomainsFor(messages);
+            foreach (TestMessage message in messages)
+            {
+                aggregator.Aggregate(message);
+            }
+
+            executed.Should().BeTrue("all messages were added to the aggregator.");
+        }
+
+        [Test]
+        public void ExecuteMultipleMessagesInDefaultDomainSeperately()
+        {
+            int count = 0;
+            MessageAggregator<TestMessage> aggregator =
+                new MessageAggregator<TestMessage>(set =>
+                {
+                    count++;
+                });
+
+            TestMessage[] messages = new[] { new TestMessage(), new TestMessage(), new TestMessage() };
+            foreach (TestMessage message in messages)
+            {
+                aggregator.Aggregate(message);
+            }
+
+            count.Should().Be(3, "all messages should execute seperately.");
+        }
+
+        [Test]
+        public void DontExecuteMultipleMessagesIfOneIsMissing()
+        {
+            bool executed = false;
+            MessageAggregator<TestMessage> aggregator =
+                new MessageAggregator<TestMessage>(set =>
+                {
+                    executed = true;
+                });
+
+            TestMessage[] messages = new[] { new TestMessage(), new TestMessage(), new TestMessage() };
+            MessageDomain.CreateNewDomainsFor(messages);
+            aggregator.Aggregate(messages[0]);
+            aggregator.Aggregate(messages[1]);
+
+            executed.Should().BeFalse("not all messages were added to the aggregator.");
+        }
+
+        [Test]
+        public void TerminateMessageDomainAutomatically()
+        {
+            bool executed = false;
+            MessageAggregator<TestMessage> aggregator =
+                new MessageAggregator<TestMessage>(set =>
+                {
+                    executed = true;
+                });
+
+            TestMessage[] messages = new[] { new TestMessage(), new TestMessage(), new TestMessage() };
+            MessageDomain.CreateNewDomainsFor(messages);
+            foreach (TestMessage message in messages)
+            {
+                aggregator.Aggregate(message);
+            }
+
+            foreach (TestMessage message in messages)
+            {
+                message.MessageDomain.IsTerminated.Should().BeTrue("message domain should have been terminated.");
+            }
+        }
+
+        [Test]
+        public void DoNotTerminateMessageDomainWhenParameterIsFalse()
+        {
+            bool executed = false;
+            MessageAggregator<TestMessage> aggregator =
+                new MessageAggregator<TestMessage>(set =>
+                {
+                    executed = true;
+                }, false);
+
+            TestMessage[] messages = new[] { new TestMessage(), new TestMessage(), new TestMessage() };
+            MessageDomain.CreateNewDomainsFor(messages);
+            foreach (TestMessage message in messages)
+            {
+                aggregator.Aggregate(message);
+            }
+
+            foreach (TestMessage message in messages)
+            {
+                message.MessageDomain.IsTerminated.Should().BeFalse("message domain should not have been terminated.");
+            }
+        }
+
+        [Test]
+        public void DoNotTerminateDefaultDomain()
+        {
+            bool executed = false;
+            MessageAggregator<TestMessage> aggregator =
+                new MessageAggregator<TestMessage>(set =>
+                {
+                    executed = true;
+                });
+
+            aggregator.Aggregate(new TestMessage());
+
+            MessageDomain.DefaultMessageDomain.IsTerminated.Should().BeFalse("the default message domain should never be terminated.");
+        }
+    }
+}

--- a/src/Agents.Net/GlobalSuppressions.cs
+++ b/src/Agents.Net/GlobalSuppressions.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright
+#region Copyright
 //  Copyright (c) Tobias Wilker and contributors
 //  This file is licensed under MIT
 #endregion
@@ -21,3 +21,4 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Design", "CA1021:Avoid out parameters", Justification = "Internally used protected method in public class.", Scope = "member", Target = "~M:Agents.Net.MessageCollector`6.IsCompleted(Agents.Net.MessageDomain,Agents.Net.MessageCollection@)~System.Boolean")]
 [assembly: SuppressMessage("Design", "CA1021:Avoid out parameters", Justification = "Internally used protected method in public class.", Scope = "member", Target = "~M:Agents.Net.MessageCollector`7.IsCompleted(Agents.Net.MessageDomain,Agents.Net.MessageCollection@)~System.Boolean")]
 [assembly: SuppressMessage("Maintainability", "CA1501:Avoid excessive inheritance", Justification = "I assume this is common practise for this case.", Scope = "type", Target = "~T:Agents.Net.MessageCollection`7")]
+[assembly: SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "Message is not used and has no disposable parts.", Scope = "member", Target = "~M:Agents.Net.MessageAggregator`1.Aggregate(Agents.Net.Message)")]

--- a/src/Agents.Net/MessageDomain.cs
+++ b/src/Agents.Net/MessageDomain.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright
+#region Copyright
 //  Copyright (c) Tobias Wilker and contributors
 //  This file is licensed under MIT
 #endregion
@@ -55,7 +55,7 @@ namespace Agents.Net
         {
             Root = root;
             Parent = parent;
-            SiblingDomainRootMessages = siblingDomainRootMessages ?? Array.Empty<Message>();
+            SiblingDomainRootMessages = siblingDomainRootMessages ?? new[] { root };
             lock (parent?.children??new object())
             {
                 parent?.children.Add(this);
@@ -117,6 +117,10 @@ namespace Agents.Net
             IEnumerable<MessageDomain> terminatingDomains = domainMessages.Select(m => m.MessageDomain).Distinct().ToArray();
             foreach (MessageDomain terminatedDomain in terminatingDomains)
             {
+                if(terminatedDomain == DefaultMessageDomain)
+                {
+                    continue;
+                }
                 terminatedDomain.Terminate();
             }
             return new MessageDomainTerminatedMessage(domainMessages, terminatingDomains);


### PR DESCRIPTION
## Description

This reduces the boilerplpate code which is necessary. There is a new optional parameter for the aggregator constructor which can deactivate this behaviour.

Fixes #82 

## How Has This Been Tested?

- new uni test MessageAggregatorTest

## Checklist:

<!-- To check one of the checkboxes just change [ ] to [x]-->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
- [x] I have added an entry to the [changelog](https://github.com/agents-net/agents.net/blob/master/CHANGELOG.md) if necessary
