### PR TITLE
Replaced FindSetsForDomain with PushAndExecute to make it more reliable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## [Unreleased]
 ### Changed
+- MessageAggregator automatically terminates the message domains of the aggregated messages. Can be disabled with optional constructor parameter.
 - **Breaking Change:** Removed the `Predecessors` and `GetPredecessor` members from `Message`. This was a huge unfixable memory leak. Instead of it `MessageDomain` and `MessageCollector` should be used to address scenarios where the predecessor message must be evaluated
 - `MessageAggregator` automatically terminates the message domains of the aggregated messages. Can be disabled with optional constructor parameter
 - `MessageCollector` automatically removes messages from a terminated domain. This was a huge memory leak
 
+### Added
+- `MessageCollector.PushAndExecute` is a replacement for `MessageCollector.FindSetsForDomain`. It adds a message to the collector and waits for a complete set with that message to execute an action
+
 ### Removed
 - **Breaking Change:** Removed useless `MessageDomainsCreatedMessage` and `MessageDomainsTerminatedMessage`
+- **Breaking Change:** Removed the `MessageCollector.FindSetsForDomain` method. Use the new `MessageCollector.PushAndExecute` method instead
 
 ### Fixed
 - `MessageDomain` did not dispose replaced messages. This is now fixed

--- a/src/Agents.Net/Message.cs
+++ b/src/Agents.Net/Message.cs
@@ -29,8 +29,6 @@ namespace Agents.Net
     {
         private Message parent;
 
-        internal Type[] PredecessorTypes { get; private set; }
-
         internal Guid[] PredecessorIds { get; private set; }
 
         private readonly string name;
@@ -72,22 +70,18 @@ namespace Agents.Net
             MessageType = GetType();
             Message[] predecessorHierarchy = predecessorMessages.SelectMany(m => m.HeadMessage.DescendantsAndSelf)
                                                                 .ToArray();
-            PredecessorTypes = predecessorHierarchy.Select(m => m.MessageType)
-                                                   .ToArray();
             PredecessorIds = predecessorHierarchy.Select(m => m.Id)
                                                  .ToArray();
             MessageDomain = predecessorHierarchy.GetMessageDomain();
             DescendantsAndSelf = new[] {this};
         }
 
-        internal Message(IEnumerable<Type> predecessorTypes, IEnumerable<Guid> predecessorIds, IEnumerable<Message> predecessorMessages, string name = null)
+        internal Message(IEnumerable<Guid> predecessorIds, IEnumerable<Message> predecessorMessages, string name = null)
         {
             this.name = string.IsNullOrEmpty(name) ? GetType().Name : name;
             MessageType = GetType();
             Message[] predecessorHierarchy = predecessorMessages.SelectMany(m => m.HeadMessage.DescendantsAndSelf)
                                                                 .ToArray();
-            this.PredecessorTypes = predecessorTypes.Concat(predecessorHierarchy.Select(m => m.MessageType))
-                                                    .ToArray();
             this.PredecessorIds = predecessorIds.Concat(predecessorHierarchy.Select(m => m.Id))
                                                 .ToArray();
             DescendantsAndSelf = new[] {this};
@@ -121,7 +115,6 @@ namespace Agents.Net
             }
 
             message.SetChild(Child);
-            message.PredecessorTypes = PredecessorTypes;
             message.PredecessorIds = PredecessorIds;
             message.SwitchDomain(MessageDomain);
             message.parent = parent;
@@ -182,21 +175,6 @@ namespace Agents.Net
         public bool Is<T>() where T : Message
         {
             return TryGet(out T _);
-        }
-
-        /// <summary>
-        /// Checks whether there was a direct predecessor of the given type.
-        /// </summary>
-        /// <typeparam name="T">Assumed type of the direct predecessor.</typeparam>
-        /// <returns><c>true</c>, if there was a direct predecessor of the specified predecessor type, otherwise <c>false</c>.</returns>
-        /// <remarks>
-        /// This might be deleted in the future if it is obvious that it is useless.
-        /// </remarks>
-        public bool HadPredecessor<T>()
-            where T : Message
-        {
-            Type predecessorType = typeof(T);
-            return PredecessorTypes.Any(predecessorType.IsAssignableFrom);
         }
 
         /// <summary>

--- a/src/Agents.Net/MessageDecorator.cs
+++ b/src/Agents.Net/MessageDecorator.cs
@@ -57,7 +57,7 @@ namespace Agents.Net
         /// The <paramref name="decoratedMessage"/> is not necessarily the direct <see cref="Message.Child"/> of this message, as it is undetermined which message decorator comes first when two decorators are applied at the same time. But it is thread safe to do so. 
         /// </remarks>
         protected MessageDecorator(Message decoratedMessage, IEnumerable<Message> additionalPredecessors = null) 
-            : base(decoratedMessage?.PredecessorTypes??Enumerable.Empty<Type>(), decoratedMessage?.PredecessorIds??Enumerable.Empty<Guid>(), additionalPredecessors ?? Enumerable.Empty<Message>())
+            : base(decoratedMessage?.PredecessorIds??Enumerable.Empty<Guid>(), additionalPredecessors ?? Enumerable.Empty<Message>())
         {
             SwitchDomain(decoratedMessage?.MessageDomain);
             SetChild(decoratedMessage?.ReplaceHead(this));


### PR DESCRIPTION
## Description

Previously if interceptors needed a message collector, there was only the method `FindSetsForDomain`. This assumed that all messages were already inside the collector which is not always the case. With the new `PushAndExecute `method the execution waits for all messages to be collected.

Fixes #86

## How Has This Been Tested?

- MessageCollectorTest.PushAndExecuteStoresMessages
- MessageCollectorTest.ConsumedMessageIsRemovedFromCollectorUsingPushAndExecute
- MessageCollectorTest.ExecutePushedMessageIfSetIsFull
- MessageCollectorTest.ExecutePushedMessageIfSetIsFilledLater
- MessageCollectorTest.ExecutePushedMessageOnlyOnce
- MessageCollectorTest.ExecuteOriginalActionToo
- Changed all tests that used FindSetsForDomain

## Checklist:

<!-- To check one of the checkboxes just change [ ] to [x]-->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
- [x] I have added an entry to the [changelog](https://github.com/agents-net/agents.net/blob/master/CHANGELOG.md) if necessary
