### PR TITLE
Add thread-safe way to add disposables for agents.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## [Unreleased]
 ### Changed
-- MessageAggregator automatically terminates the message domains of the aggregated messages. Can be disabled with optional constructor parameter.
 - **Breaking Change:** Removed the `Predecessors` and `GetPredecessor` members from `Message`. This was a huge unfixable memory leak. Instead of it `MessageDomain` and `MessageCollector` should be used to address scenarios where the predecessor message must be evaluated
+- **Breaking Change:** The `Agent` class implements now `IDisposable`. Disposables can now be added with the new `AddDisposable` method
 - `MessageAggregator` automatically terminates the message domains of the aggregated messages. Can be disabled with optional constructor parameter
 - `MessageCollector` automatically removes messages from a terminated domain. This was a huge memory leak
 
 ### Added
 - `MessageCollector.PushAndExecute` is a replacement for `MessageCollector.FindSetsForDomain`. It adds a message to the collector and waits for a complete set with that message to execute an action
+- `Agent.AddDisposable` marks the passed object for disposal in a thread-safe way
 
 ### Removed
 - **Breaking Change:** Removed useless `MessageDomainsCreatedMessage` and `MessageDomainsTerminatedMessage`

--- a/src/Agents.Net/Message.cs
+++ b/src/Agents.Net/Message.cs
@@ -439,7 +439,7 @@ namespace Agents.Net
         /// <summary>
         /// Dispose any resources that are stored in the message.
         /// </summary>
-        /// <param name="disposing">If <c>true</c> </param>
+        /// <param name="disposing">If <c>true</c> it was called from the <see cref="Dispose()"/> method.</param>
         protected virtual void Dispose(bool disposing)
         {
             remainingUses = 0;


### PR DESCRIPTION
## Description

Added `Agent.AddDisposable` method.

Fixes #38

## How Has This Been Tested?

- `AgentTest.DisposeAllDisposables`

## Checklist:

<!-- To check one of the checkboxes just change [ ] to [x]-->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
- [x] I have added an entry to the [changelog](https://github.com/agents-net/agents.net/blob/master/CHANGELOG.md) if necessary
