### PR TITLE
Check the whole message hierarchy.

### DIFF
--- a/src/Agents.Net.Tests/MessageCollectorTest.cs
+++ b/src/Agents.Net.Tests/MessageCollectorTest.cs
@@ -142,6 +142,20 @@ namespace Agents.Net.Tests
             executed.Should().BeTrue("this set should have been executed immediately.");
         }
         
+        [Test, Timeout(1000)]
+        public void ExecutePushedMessageIfSetIsFullWithDecorator()
+        {
+            bool executed = false;
+            MessageCollector<TestMessage, OtherMessage> collector = new MessageCollector<TestMessage, OtherMessage>();
+            collector.Push(new TestMessage());
+            collector.PushAndExecute(OtherDecorator.Decorate(new OtherMessage()), set =>
+            {
+                executed = true;
+            });
+
+            executed.Should().BeTrue("this set should have been executed immediately.");
+        }
+        
         [Test]
         public void ExecutePushedMessageIfSetIsFilledLater()
         {
@@ -376,6 +390,24 @@ namespace Agents.Net.Tests
         }
 
         #endregion
+
+        private class OtherDecorator : MessageDecorator
+        {
+            private OtherDecorator(Message decoratedMessage, IEnumerable<Message> additionalPredecessors = null)
+                : base(decoratedMessage, additionalPredecessors)
+            {
+            }
+
+            public static OtherDecorator Decorate(OtherMessage message)
+            {
+                return new OtherDecorator(message);
+            }
+
+            protected override string DataToString()
+            {
+                return string.Empty;
+            }
+        }
 
         private class OtherMessage : Message
         {

--- a/src/Agents.Net/MessageCollector.cs
+++ b/src/Agents.Net/MessageCollector.cs
@@ -256,7 +256,7 @@ namespace Agents.Net
             {
                 if (oneShotActions.Count > 0)
                 {
-                    foreach (Message message in messageSet)
+                    foreach (Message message in messageSet.SelectMany(m => m.HeadMessage.DescendantsAndSelf))
                     {
                         if (oneShotActions.TryGetValue(message, out Action<MessageCollection> action))
                         {


### PR DESCRIPTION
## Description

Check the whole message hierarchy to look for the one shot action.

Fixes #89

## How Has This Been Tested?

- `MessageCollectorTest.ExecutePushedMessageIfSetIsFullWithDecorator`

## Checklist:

<!-- To check one of the checkboxes just change [ ] to [x]-->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
- [x] I have added an entry to the [changelog](https://github.com/agents-net/agents.net/blob/master/CHANGELOG.md) if necessary
