### PR TITLE
Change nuget version, because 21.6.0 was mistakenly used

### DIFF
--- a/src/Agents.Net/NugetVersion.targets
+++ b/src/Agents.Net/NugetVersion.targets
@@ -2,7 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-	<Version>2021.6.0</Version>
+	<Version>2021.6.1</Version>
   </PropertyGroup>
  
 </Project>


### PR DESCRIPTION
## Description

Change nuget version, because 21.6.0 was mistakenly used.