### PR TITLE
SwitchDomain now changes the domain starting with the head message.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 -->
 
 ## [Unreleased]
+### Fixed
+- #93 - When changing the message domain the message domain of the whoile hierarchy is now changed
 
-## 2021.6.0
+## 2021.6.1
 ### Changed
 - **Breaking Change:** Removed the `Predecessors` and `GetPredecessor` members from `Message`. This was a huge unfixable memory leak. Instead of it `MessageDomain` and `MessageCollector` should be used to address scenarios where the predecessor message must be evaluated
 - **Breaking Change:** The `Agent` class implements now `IDisposable`. Disposables can now be added with the new `AddDisposable` method

--- a/src/Agents.Net.Tests/MessageDomainTest.cs
+++ b/src/Agents.Net.Tests/MessageDomainTest.cs
@@ -43,6 +43,16 @@ namespace Agents.Net.Tests
         }
 
         [Test]
+        public void CreateDomainSwitchesDomainForMessageHierarchy()
+        {
+            TestMessage message1 = new TestMessage();
+            TestMessageDecorator decorator = TestMessageDecorator.Decorate(message1);
+            MessageDomain.CreateNewDomainsFor(message1);
+            
+            Assert.AreEqual(message1.MessageDomain, decorator.MessageDomain, "Whole hierarchy should have the new domain.");
+        }
+
+        [Test]
         public void NewDomainIsChildOfParentDomain()
         {
             TestMessage message1 = new TestMessage();

--- a/src/Agents.Net.Tests/TestMessage.cs
+++ b/src/Agents.Net.Tests/TestMessage.cs
@@ -31,4 +31,23 @@ namespace Agents.Net.Tests
             return string.Empty;
         }
     }
+
+    public class TestMessageDecorator : MessageDecorator
+    {
+        private TestMessageDecorator(Message decoratedMessage, IEnumerable<Message> additionalPredecessors = null)
+            : base(decoratedMessage, additionalPredecessors)
+        {
+        }
+
+        public static TestMessageDecorator Decorate(TestMessage message,
+                                                    IEnumerable<Message> additionalPredecessors = null)
+        {
+            return new TestMessageDecorator(message, additionalPredecessors);
+        }
+
+        protected override string DataToString()
+        {
+            return string.Empty;
+        }
+    }
 }

--- a/src/Agents.Net/Message.cs
+++ b/src/Agents.Net/Message.cs
@@ -258,6 +258,10 @@ namespace Agents.Net
 
         internal void SwitchDomain(MessageDomain newDomain)
         {
+            if (this != HeadMessage)
+            {
+                HeadMessage.SwitchDomain(newDomain);
+            }
             MessageDomain = newDomain;
             foreach (Message descendant in Descendants)
             {


### PR DESCRIPTION
## Description

Previously only `Descendens` got the new domain. Now `SwitchDomain` starts with `HeadMessage`.

Fixes #93 

## How Has This Been Tested?

- MessageDomainTest.CreateDomainSwitchesDomainForMessageHierarchy

## Checklist:

<!-- To check one of the checkboxes just change [ ] to [x]-->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
- [x] I have added an entry to the [changelog](https://github.com/agents-net/agents.net/blob/master/CHANGELOG.md) if necessary
