### PR TITLE
Terminated domains are ignored when creating new ones.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## [Unreleased]
 ### Fixed
-- #93 - When changing the message domain the message domain of the whoile hierarchy is now changed
+- #93 - When changing the message domain the message domain of the whole hierarchy is now changed
+- #95 - Terminated domains are not considered anymore when choosing the parent for a new domain
 
 ## 2021.6.1
 ### Changed

--- a/src/Agents.Net.Tests/MessageCollectorTest.cs
+++ b/src/Agents.Net.Tests/MessageCollectorTest.cs
@@ -142,7 +142,7 @@ namespace Agents.Net.Tests
             executed.Should().BeTrue("this set should have been executed immediately.");
         }
         
-        [Test, Timeout(1000)]
+        [Test]
         public void ExecutePushedMessageIfSetIsFullWithDecorator()
         {
             bool executed = false;

--- a/src/Agents.Net/MessageDomain.cs
+++ b/src/Agents.Net/MessageDomain.cs
@@ -55,6 +55,10 @@ namespace Agents.Net
 
         private MessageDomain(Message root, MessageDomain parent, IReadOnlyCollection<Message> siblingDomainRootMessages = null)
         {
+            while (parent?.IsTerminated == true)
+            {
+                parent = parent.Parent;
+            }
             Root = root;
             Parent = parent;
             SiblingDomainRootMessages = siblingDomainRootMessages ?? new[] { root };


### PR DESCRIPTION
## Description

Terminated domains are not considered anymore when choosing the parent for a new domain.

Fixes #95 

## How Has This Been Tested?

- MessageDomainTest.CreatingNewDomainsIgnoreTerminatedDomains

## Checklist:

<!-- To check one of the checkboxes just change [ ] to [x]-->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
- [x] I have added an entry to the [changelog](https://github.com/agents-net/agents.net/blob/master/CHANGELOG.md) if necessary
