### PR TITLE
Add cancellation token to push and execute.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 -->
 
 ## [Unreleased]
+
+## 2021.6.2
+### Added
+- `PushAndExecute` accepts a `CancellationToken` now. With this it is possible to stop the wait operation
+
 ### Fixed
 - #93 - When changing the message domain the message domain of the whole hierarchy is now changed
 - #95 - Terminated domains are not considered anymore when choosing the parent for a new domain

--- a/src/Agents.Net.Tests/Features/CoreUseCases.feature
+++ b/src/Agents.Net.Tests/Features/CoreUseCases.feature
@@ -82,7 +82,7 @@ about submodules. The submodule updated is done by delaying the message the
 commiting agent is using.
 	Given I have loaded the community "DelayCommunity"
 	When I start the message board
-	Then the message "Transformed Information" was posted after at most 600 ms
+	Then the message "Transformed Information" was posted after at most 1000 ms
 	And the message "Special Information" was posted after a while
 	And the program was terminated
 

--- a/src/Agents.Net.Tests/Features/CoreUseCases.feature.cs
+++ b/src/Agents.Net.Tests/Features/CoreUseCases.feature.cs
@@ -397,7 +397,7 @@ this.ScenarioInitialize(scenarioInfo);
  testRunner.When("I start the message board", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
 #line 85
- testRunner.Then("the message \"Transformed Information\" was posted after at most 600 ms", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+ testRunner.Then("the message \"Transformed Information\" was posted after at most 1000 ms", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
 #line 86
  testRunner.And("the message \"Special Information\" was posted after a while", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");

--- a/src/Agents.Net/MessageCollector.cs
+++ b/src/Agents.Net/MessageCollector.cs
@@ -187,13 +187,15 @@ namespace Agents.Net
         /// </summary>
         /// <param name="message">The message which is added to the collector.</param>
         /// <param name="onCollected">The action which is executed when the complete set is found.</param>
+        /// <param name="cancellationToken">Cancellation token to stop the wait operation.</param>
         /// <remarks>
         /// <para>This method is helpful for <see cref="InterceptorAgent"/>s where the agent in the <see cref="InterceptorAgent.InterceptCore"/> method must wait for a set of message before returning the <see cref="InterceptionAction"/>.</para>
         /// <para>Another example is when the <see cref="InterceptorAgent"/> wants to wait on a single message. In this case the first message is the message that is intercepted. The second message is the message the agent needs. The advantage is, that the collector respects message domains.</para>
         /// </remarks>
-        public void PushAndExecute(Message message, Action<MessageCollection<T1, T2>> onCollected)
+        /// <returns><c>true</c> if the action was executed; otherwise <c>false</c>.</returns>
+        public bool PushAndExecute(Message message, Action<MessageCollection<T1, T2>> onCollected, CancellationToken cancellationToken = default)
         {
-            ExecutePushAndExecute(message, collection => onCollected((MessageCollection<T1, T2>) collection));
+            return ExecutePushAndExecute(message, collection => onCollected((MessageCollection<T1, T2>) collection), cancellationToken);
         }
 
         /// <summary>
@@ -201,7 +203,10 @@ namespace Agents.Net
         /// </summary>
         /// <param name="message">The message which is pushed.</param>
         /// <param name="executeAction">The action which should execute the action which was passed to the <see cref="PushAndExecute"/> method.</param>
-        protected void ExecutePushAndExecute(Message message, Action<MessageCollection> executeAction)
+        /// <param name="cancellationToken">Cancellation token to stop the wait operation.</param>
+        /// <returns><c>true</c> if the action was executed; otherwise <c>false</c>.</returns>
+        protected bool ExecutePushAndExecute(Message message, Action<MessageCollection> executeAction,
+                                             CancellationToken cancellationToken)
         {
             using (ManualResetEventSlim resetEvent = new ManualResetEventSlim(false))
             {
@@ -220,10 +225,19 @@ namespace Agents.Net
                 }
                 
                 Push(message);
-                resetEvent.Wait();
-                
+                try
+                {
+                    resetEvent.Wait(cancellationToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    return false;
+                }
+
                 executeAction?.Invoke(collection);
             }
+
+            return true;
         }
 
         /// <summary>
@@ -506,13 +520,15 @@ namespace Agents.Net
         /// </summary>
         /// <param name="message">The message which is added to the collector.</param>
         /// <param name="onCollected">The action which is executed when the complete set is found.</param>
+        /// <param name="cancellationToken">Cancellation token to stop the wait operation.</param>
         /// <remarks>
         /// <para>This method is helpful for <see cref="InterceptorAgent"/>s where the agent in the <see cref="InterceptorAgent.InterceptCore"/> method must wait for a set of message before returning the <see cref="InterceptionAction"/>.</para>
         /// <para>Another example is when the <see cref="InterceptorAgent"/> wants to wait on a single message. In this case the first message is the message that is intercepted. The second message is the message the agent needs. The advantage is, that the collector respects message domains.</para>
         /// </remarks>
-        public void PushAndExecute(Message message, Action<MessageCollection<T1, T2, T3>> onCollected)
+        /// <returns><c>true</c> if the action was executed; otherwise <c>false</c>.</returns>
+        public bool PushAndExecute(Message message, Action<MessageCollection<T1, T2, T3>> onCollected, CancellationToken cancellationToken = default)
         {
-            ExecutePushAndExecute(message, collection => onCollected((MessageCollection<T1, T2, T3>) collection));
+            return ExecutePushAndExecute(message, collection => onCollected((MessageCollection<T1, T2, T3>) collection), cancellationToken);
         }
     }
 
@@ -591,13 +607,15 @@ namespace Agents.Net
         /// </summary>
         /// <param name="message">The message which is added to the collector.</param>
         /// <param name="onCollected">The action which is executed when the complete set is found.</param>
+        /// <param name="cancellationToken">Cancellation token to stop the wait operation.</param>
         /// <remarks>
         /// <para>This method is helpful for <see cref="InterceptorAgent"/>s where the agent in the <see cref="InterceptorAgent.InterceptCore"/> method must wait for a set of message before returning the <see cref="InterceptionAction"/>.</para>
         /// <para>Another example is when the <see cref="InterceptorAgent"/> wants to wait on a single message. In this case the first message is the message that is intercepted. The second message is the message the agent needs. The advantage is, that the collector respects message domains.</para>
         /// </remarks>
-        public void PushAndExecute(Message message, Action<MessageCollection<T1, T2, T3, T4>> onCollected)
+        /// <returns><c>true</c> if the action was executed; otherwise <c>false</c>.</returns>
+        public bool PushAndExecute(Message message, Action<MessageCollection<T1, T2, T3, T4>> onCollected, CancellationToken cancellationToken = default)
         {
-            ExecutePushAndExecute(message, collection => onCollected((MessageCollection<T1, T2, T3, T4>) collection));
+            return ExecutePushAndExecute(message, collection => onCollected((MessageCollection<T1, T2, T3, T4>) collection), cancellationToken);
         }
     }
 
@@ -678,13 +696,15 @@ namespace Agents.Net
         /// </summary>
         /// <param name="message">The message which is added to the collector.</param>
         /// <param name="onCollected">The action which is executed when the complete set is found.</param>
+        /// <param name="cancellationToken">Cancellation token to stop the wait operation.</param>
         /// <remarks>
         /// <para>This method is helpful for <see cref="InterceptorAgent"/>s where the agent in the <see cref="InterceptorAgent.InterceptCore"/> method must wait for a set of message before returning the <see cref="InterceptionAction"/>.</para>
         /// <para>Another example is when the <see cref="InterceptorAgent"/> wants to wait on a single message. In this case the first message is the message that is intercepted. The second message is the message the agent needs. The advantage is, that the collector respects message domains.</para>
         /// </remarks>
-        public void PushAndExecute(Message message, Action<MessageCollection<T1, T2, T3, T4, T5>> onCollected)
+        /// <returns><c>true</c> if the action was executed; otherwise <c>false</c>.</returns>
+        public bool PushAndExecute(Message message, Action<MessageCollection<T1, T2, T3, T4, T5>> onCollected, CancellationToken cancellationToken = default)
         {
-            ExecutePushAndExecute(message, collection => onCollected((MessageCollection<T1, T2, T3, T4, T5>) collection));
+            return ExecutePushAndExecute(message, collection => onCollected((MessageCollection<T1, T2, T3, T4, T5>) collection), cancellationToken);
         }
     }
 
@@ -767,13 +787,15 @@ namespace Agents.Net
         /// </summary>
         /// <param name="message">The message which is added to the collector.</param>
         /// <param name="onCollected">The action which is executed when the complete set is found.</param>
+        /// <param name="cancellationToken">Cancellation token to stop the wait operation.</param>
         /// <remarks>
         /// <para>This method is helpful for <see cref="InterceptorAgent"/>s where the agent in the <see cref="InterceptorAgent.InterceptCore"/> method must wait for a set of message before returning the <see cref="InterceptionAction"/>.</para>
         /// <para>Another example is when the <see cref="InterceptorAgent"/> wants to wait on a single message. In this case the first message is the message that is intercepted. The second message is the message the agent needs. The advantage is, that the collector respects message domains.</para>
         /// </remarks>
-        public void PushAndExecute(Message message, Action<MessageCollection<T1, T2, T3, T4, T5, T6>> onCollected)
+        /// <returns><c>true</c> if the action was executed; otherwise <c>false</c>.</returns>
+        public bool PushAndExecute(Message message, Action<MessageCollection<T1, T2, T3, T4, T5, T6>> onCollected, CancellationToken cancellationToken = default)
         {
-            ExecutePushAndExecute(message, collection => onCollected((MessageCollection<T1, T2, T3, T4, T5, T6>) collection));
+            return ExecutePushAndExecute(message, collection => onCollected((MessageCollection<T1, T2, T3, T4, T5, T6>) collection), cancellationToken);
         }
     }
 
@@ -858,13 +880,15 @@ namespace Agents.Net
         /// </summary>
         /// <param name="message">The message which is added to the collector.</param>
         /// <param name="onCollected">The action which is executed when the complete set is found.</param>
+        /// <param name="cancellationToken">Cancellation token to stop the wait operation.</param>
         /// <remarks>
         /// <para>This method is helpful for <see cref="InterceptorAgent"/>s where the agent in the <see cref="InterceptorAgent.InterceptCore"/> method must wait for a set of message before returning the <see cref="InterceptionAction"/>.</para>
         /// <para>Another example is when the <see cref="InterceptorAgent"/> wants to wait on a single message. In this case the first message is the message that is intercepted. The second message is the message the agent needs. The advantage is, that the collector respects message domains.</para>
         /// </remarks>
-        public void PushAndExecute(Message message, Action<MessageCollection<T1, T2, T3, T4, T5, T6, T7>> onCollected)
+        /// <returns><c>true</c> if the action was executed; otherwise <c>false</c>.</returns>
+        public bool PushAndExecute(Message message, Action<MessageCollection<T1, T2, T3, T4, T5, T6, T7>> onCollected, CancellationToken cancellationToken = default)
         {
-            ExecutePushAndExecute(message, collection => onCollected((MessageCollection<T1, T2, T3, T4, T5, T6, T7>) collection));
+            return ExecutePushAndExecute(message, collection => onCollected((MessageCollection<T1, T2, T3, T4, T5, T6, T7>) collection), cancellationToken);
         }
     }
 }

--- a/src/Agents.Net/NugetVersion.targets
+++ b/src/Agents.Net/NugetVersion.targets
@@ -2,7 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-	<Version>2021.6.1</Version>
+	<Version>2021.6.2</Version>
   </PropertyGroup>
  
 </Project>


### PR DESCRIPTION
## Description

With that push and execute can be stopped for example when an exception message was send.

Fixes #97 

## How Has This Been Tested?

- MessageCollectorTest.CancelPushAndExecute
- MessageCollectorTest.CancelPushAndExecuteAndAfterwardsPushDoesNotExecuteAction

## Checklist:

<!-- To check one of the checkboxes just change [ ] to [x]-->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
- [x] I have added an entry to the [changelog](https://github.com/agents-net/agents.net/blob/master/CHANGELOG.md) if necessary
