### PR TITLE
Replace message id with replace method. Add message test.

### DIFF
--- a/src/Agents.Net.Tests/MessageTest.cs
+++ b/src/Agents.Net.Tests/MessageTest.cs
@@ -1,0 +1,67 @@
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Agents.Net.Tests
+{
+    public class MessageTest
+    {
+        [Test]
+        public void ReplaceMessageInheritsPredecessorIds()
+        {
+            TestMessage origin = new TestMessage();
+            TestMessage context = new TestMessage(origin);
+            TestMessage replacing = new TestMessage();
+            context.ReplaceWith(replacing);
+
+            replacing.ToMessageLog().Predecessors.Should().BeEquivalentTo(context.ToMessageLog().Predecessors);
+        }
+        
+        [Test]
+        public void ReplaceMessageInheritsChild()
+        {
+            TestMessage child = new TestMessage();
+            TestMessageDecorator context = TestMessageDecorator.Decorate(child);
+            TestMessageDecorator replacing = TestMessageDecorator.Decorate(null);
+            context.ReplaceWith(replacing);
+
+            replacing.ToMessageLog().Child.Id.Should().Be(child.Id);
+        }
+        
+        [Test]
+        public void ReplaceMessageInheritsMessageDomain()
+        {
+            TestMessage context = new TestMessage();
+            MessageDomain.CreateNewDomainsFor(context);
+            TestMessage replacing = new TestMessage();
+            context.ReplaceWith(replacing);
+
+            replacing.ToMessageLog().Domain.Should().Be(context.ToMessageLog().Domain);
+        }
+        
+        [Test]
+        public void ReplaceMessageReplacesParentConnection()
+        {
+            TestMessage context = new TestMessage();
+            TestMessageDecorator decorator = TestMessageDecorator.Decorate(context);
+            TestMessage replacing = new TestMessage();
+            context.ReplaceWith(replacing);
+
+            replacing.HeadMessage.Should().Be(decorator);
+            decorator.DescendantsAndSelf.Should().Contain(replacing);
+            foreach (Message descendant in decorator.DescendantsAndSelf)
+            {
+                descendant.Should().NotBeSameAs(context);
+            }
+        }
+        
+        [Test]
+        public void ReplaceMessageInheritsMessageId()
+        {
+            TestMessage context = new TestMessage();
+            TestMessage replacing = new TestMessage();
+            context.ReplaceWith(replacing);
+
+            replacing.Id.Should().Be(context.Id);
+        }
+    }
+}

--- a/src/Agents.Net/Agents.Net.csproj
+++ b/src/Agents.Net/Agents.Net.csproj
@@ -36,6 +36,12 @@
   <ItemGroup>
     <None Include="Icon.png" Pack="true" PackagePath="\" />
   </ItemGroup>
+
+  <ItemGroup>
+      <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+          <_Parameter1>$(AssemblyName).Tests</_Parameter1>
+      </AssemblyAttribute>
+  </ItemGroup>
   
   <ItemGroup>
     <PackageReference Include="Serilog" Version="2.10.0" />

--- a/src/Agents.Net/Message.cs
+++ b/src/Agents.Net/Message.cs
@@ -41,7 +41,7 @@ namespace Agents.Net
         /// <remarks>
         /// The id is only used for logging.
         /// </remarks>
-        public Guid Id { get; } = Guid.NewGuid();
+        public Guid Id { get; private set; } = Guid.NewGuid();
 
         /// <summary>
         /// Initializes a new instances of this class with a single predecessor message.
@@ -118,6 +118,7 @@ namespace Agents.Net
             message.PredecessorIds = PredecessorIds;
             message.SwitchDomain(MessageDomain);
             message.parent = parent;
+            message.Id = Id;
             parent?.SetChild(message);
         }
 


### PR DESCRIPTION
## Description

`ReplaceWith` inherits now the id of the replaced message too.

Fixes #99

## How Has This Been Tested?

- `MessageTest` added

## Checklist:

<!-- To check one of the checkboxes just change [ ] to [x]-->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
- [x] I have added an entry to the [changelog](https://github.com/agents-net/agents.net/blob/master/CHANGELOG.md) if necessary
