### PR TITLE
Update descendants of whole hierarchy with replace.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 -->
 
 ## [Unreleased]
+### Fixed
+- #99 - Replace inherits id and updates the whole hierarchies descendants
 
 ## 2021.6.2
 ### Added

--- a/src/Agents.Net.Tests/MessageTest.cs
+++ b/src/Agents.Net.Tests/MessageTest.cs
@@ -63,5 +63,23 @@ namespace Agents.Net.Tests
 
             replacing.Id.Should().Be(context.Id);
         }
+        
+        [Test]
+        public void ReplaceMessageChangesDescendantsOfWholeHierarchy()
+        {
+            TestMessage context = new TestMessage();
+            TestMessageDecorator decorator = TestMessageDecorator.Decorate(context);
+            TestMessageDecorator head = TestMessageDecorator.Decorate(decorator);
+            TestMessage replacing = new TestMessage();
+            context.ReplaceWith(replacing);
+
+            bool found = false;
+            foreach (Message descendant in head.DescendantsAndSelf)
+            {
+                found |= ReferenceEquals(descendant, replacing);
+            }
+
+            found.Should().BeTrue("the head message should now the new child message.");
+        }
     }
 }

--- a/src/Agents.Net.Tests/TestMessage.cs
+++ b/src/Agents.Net.Tests/TestMessage.cs
@@ -39,7 +39,7 @@ namespace Agents.Net.Tests
         {
         }
 
-        public static TestMessageDecorator Decorate(TestMessage message,
+        public static TestMessageDecorator Decorate(Message message,
                                                     IEnumerable<Message> additionalPredecessors = null)
         {
             return new TestMessageDecorator(message, additionalPredecessors);

--- a/src/Agents.Net/Message.cs
+++ b/src/Agents.Net/Message.cs
@@ -163,6 +163,7 @@ namespace Agents.Net
 
             Descendants = Child?.Descendants.Concat(new[] {Child})
                           ?? Array.Empty<Message>();
+            parent?.SetChild(this);
         }
 
         /// <summary>


### PR DESCRIPTION
## Description

Previously only the parent descendants were replaced.

Fixes #99

## How Has This Been Tested?

- `MessageTest.ReplaceMessageChangesDescendantsOfWholeHierarchy`

## Checklist:

<!-- To check one of the checkboxes just change [ ] to [x]-->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
- [x] I have added an entry to the [changelog](https://github.com/agents-net/agents.net/blob/master/CHANGELOG.md) if necessary
