### PR TITLE
Message gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Fixed
 - #99 - Replace inherits id and updates the whole hierarchies descendants
 
+### Added
+- #102 - A new helper class `MessageGate` was introduced which helps covering mainly legacy uses cases
+
 ## 2021.6.2
 ### Added
 - `PushAndExecute` accepts a `CancellationToken` now. With this it is possible to stop the wait operation

--- a/src/Agents.Net.Tests/Features/CoreUseCases.feature
+++ b/src/Agents.Net.Tests/Features/CoreUseCases.feature
@@ -111,7 +111,7 @@ all exception messages as recoverable.
 	And the program was not terminated
 
 Scenario: Defensive programming community terminates on unrecoverable exception
-This scenario shows an use case where it is show how the agent framework can be 
+This scenario shows an use case where it is shown how the agent framework can be 
 used to program defensively. In this use case the FaultyInterceptor produces an
 unrecoverable exception which is logged and the program is terminated. Remember
 if there is not exception message handling agent, the agent framework will treat
@@ -121,3 +121,21 @@ all exception messages as recoverable.
 	When I start the message board
 	Then the message "Unrecoverable Exception" was posted after a while
 	And the program was terminated
+
+Scenario: Legacy service community executes a service call
+This scenario shows an use case where it is shown how the agent framework can be
+used in a legacy use case. In this use case a call to a service is made which
+excepts some parameters and expects a result.
+    Given I have loaded the community "LegacyServiceBridgeCommunity"
+	When I start the message board
+    And Call the legacy service with the data "false"
+	Then the legacy service returned "ServiceCallResult"
+
+Scenario: Legacy service community handles an exception
+This scenario shows an use case where it is shown how the agent framework can be
+used in a legacy use case. In this use case a call to a service is made which
+creates an exception that changes the service outcome.
+    Given I have loaded the community "LegacyServiceBridgeCommunity"
+	When I start the message board
+    And Call the legacy service with the data "true"
+	Then the legacy service returned "Exception"

--- a/src/Agents.Net.Tests/Features/CoreUseCases.feature.cs
+++ b/src/Agents.Net.Tests/Features/CoreUseCases.feature.cs
@@ -513,7 +513,7 @@ this.ScenarioInitialize(scenarioInfo);
         {
             string[] tagsOfScenario = ((string[])(null));
             System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
-            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Defensive programming community terminates on unrecoverable exception", @"This scenario shows an use case where it is show how the agent framework can be 
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Defensive programming community terminates on unrecoverable exception", @"This scenario shows an use case where it is shown how the agent framework can be 
 used to program defensively. In this use case the FaultyInterceptor produces an
 unrecoverable exception which is logged and the program is terminated. Remember
 if there is not exception message handling agent, the agent framework will treat
@@ -552,6 +552,96 @@ this.ScenarioInitialize(scenarioInfo);
 #line hidden
 #line 123
  testRunner.And("the program was terminated", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+            }
+            this.ScenarioCleanup();
+        }
+        
+        [NUnit.Framework.TestAttribute()]
+        [NUnit.Framework.DescriptionAttribute("Legacy service community executes a service call")]
+        public virtual void LegacyServiceCommunityExecutesAServiceCall()
+        {
+            string[] tagsOfScenario = ((string[])(null));
+            System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Legacy service community executes a service call", "This scenario shows an use case where it is shown how the agent framework can be\r" +
+                    "\nused in a legacy use case. In this use case a call to a service is made which\r\n" +
+                    "excepts some parameters and expects a result.", tagsOfScenario, argumentsOfScenario);
+#line 125
+this.ScenarioInitialize(scenarioInfo);
+#line hidden
+            bool isScenarioIgnored = default(bool);
+            bool isFeatureIgnored = default(bool);
+            if ((tagsOfScenario != null))
+            {
+                isScenarioIgnored = tagsOfScenario.Where(__entry => __entry != null).Where(__entry => String.Equals(__entry, "ignore", StringComparison.CurrentCultureIgnoreCase)).Any();
+            }
+            if ((this._featureTags != null))
+            {
+                isFeatureIgnored = this._featureTags.Where(__entry => __entry != null).Where(__entry => String.Equals(__entry, "ignore", StringComparison.CurrentCultureIgnoreCase)).Any();
+            }
+            if ((isScenarioIgnored || isFeatureIgnored))
+            {
+                testRunner.SkipScenario();
+            }
+            else
+            {
+                this.ScenarioStart();
+#line 129
+    testRunner.Given("I have loaded the community \"LegacyServiceBridgeCommunity\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
+#line hidden
+#line 130
+ testRunner.When("I start the message board", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+#line 131
+    testRunner.And("Call the legacy service with the data \"false\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 132
+ testRunner.Then("the legacy service returned \"ServiceCallResult\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line hidden
+            }
+            this.ScenarioCleanup();
+        }
+        
+        [NUnit.Framework.TestAttribute()]
+        [NUnit.Framework.DescriptionAttribute("Legacy service community handles an exception")]
+        public virtual void LegacyServiceCommunityHandlesAnException()
+        {
+            string[] tagsOfScenario = ((string[])(null));
+            System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Legacy service community handles an exception", "This scenario shows an use case where it is shown how the agent framework can be\r" +
+                    "\nused in a legacy use case. In this use case a call to a service is made which\r\n" +
+                    "creates an exception that changes the service outcome.", tagsOfScenario, argumentsOfScenario);
+#line 134
+this.ScenarioInitialize(scenarioInfo);
+#line hidden
+            bool isScenarioIgnored = default(bool);
+            bool isFeatureIgnored = default(bool);
+            if ((tagsOfScenario != null))
+            {
+                isScenarioIgnored = tagsOfScenario.Where(__entry => __entry != null).Where(__entry => String.Equals(__entry, "ignore", StringComparison.CurrentCultureIgnoreCase)).Any();
+            }
+            if ((this._featureTags != null))
+            {
+                isFeatureIgnored = this._featureTags.Where(__entry => __entry != null).Where(__entry => String.Equals(__entry, "ignore", StringComparison.CurrentCultureIgnoreCase)).Any();
+            }
+            if ((isScenarioIgnored || isFeatureIgnored))
+            {
+                testRunner.SkipScenario();
+            }
+            else
+            {
+                this.ScenarioStart();
+#line 138
+    testRunner.Given("I have loaded the community \"LegacyServiceBridgeCommunity\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
+#line hidden
+#line 139
+ testRunner.When("I start the message board", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+#line 140
+    testRunner.And("Call the legacy service with the data \"true\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 141
+ testRunner.Then("the legacy service returned \"Exception\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
             }
             this.ScenarioCleanup();

--- a/src/Agents.Net.Tests/MessageGateTest.cs
+++ b/src/Agents.Net.Tests/MessageGateTest.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Agents.Net.Tests.Tools.Communities.HelloWorldCommunity.Agents;
+using FluentAssertions;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Agents.Net.Tests
+{
+    public class MessageGateTest
+    {
+        [Test]
+        public void ContinueExecutionIfEndMessageWasSend()
+        {
+            bool executed = false;
+            TestMessage startMessage = new TestMessage();
+            using ManualResetEventSlim resetEvent = new ManualResetEventSlim(false);
+            MessageGate<TestMessage, OtherMessage> gate = new MessageGate<TestMessage, OtherMessage>();
+            using Timer timer = new Timer(state =>
+                                          {
+                                              executed.Should().BeFalse("The gate should not continue before pushing end message.");
+                                              gate.Check(new OtherMessage(startMessage));
+                                              resetEvent.Set();
+                                          }, null, 200,
+                                          Timeout.Infinite);
+            gate.SendAndAwait(startMessage);
+            executed = true;
+            resetEvent.Wait();
+        }
+        
+        [Test]
+        public void ReturnEndMessageIfSuccess()
+        {
+            TestMessage startMessage = new TestMessage();
+            MessageGate<TestMessage, OtherMessage> gate = new MessageGate<TestMessage, OtherMessage>();
+            OtherMessage endMessage = null;
+            
+            using Timer timer = new Timer(state =>
+                                          {
+                                              endMessage = new OtherMessage(startMessage);
+                                              gate.Check(endMessage);
+                                          }, null, 200,
+                                          Timeout.Infinite);
+            MessageGateResult<OtherMessage> result = gate.SendAndAwait(startMessage);
+
+            result.Result.Should().Be(MessageGateResultKind.Success);
+            result.EndMessage.Should().BeSameAs(endMessage);
+        }
+        
+        [Test]
+        public void ReturnExceptionMessageIfUnsuccessful()
+        {
+            TestMessage startMessage = new TestMessage();
+            MessageGate<TestMessage, OtherMessage> gate = new MessageGate<TestMessage, OtherMessage>();
+            ExceptionMessage exception = null;
+            
+            using Timer timer = new Timer(state =>
+                                          {
+                                              exception = new ExceptionMessage("Error", startMessage, new HelloAgent(Substitute.For<IMessageBoard>()));
+                                              gate.Check(exception);
+                                          }, null, 200,
+                                          Timeout.Infinite);
+            MessageGateResult<OtherMessage> result = gate.SendAndAwait(startMessage);
+
+            result.Result.Should().Be(MessageGateResultKind.Exception);
+            result.Exceptions.Should().ContainSingle(message => ReferenceEquals(message, exception));
+        }
+        
+        [Test]
+        public void TimeoutIfEndMessageIsOutsideOfMessageDomain()
+        {
+            TestMessage startMessage = new TestMessage();
+            MessageGate<TestMessage, OtherMessage> gate = new MessageGate<TestMessage, OtherMessage>();
+            bool executed = false;
+            
+            using Timer timer = new Timer(state =>
+                                          {
+                                              OtherMessage endMessage = new OtherMessage(Array.Empty<Message>());
+                                              gate.Check(endMessage);
+                                              executed = true;
+                                          }, null, 200,
+                                          Timeout.Infinite);
+            MessageGateResult<OtherMessage> result = gate.SendAndAwait(startMessage, 500);
+
+            executed.Should().BeTrue("otherwise there is a timing issue.");
+            result.Result.Should().Be(MessageGateResultKind.Timeout);
+        }
+        
+        [Test]
+        public void TimeoutIfExceptionMessageIsOutsideOfMessageDomain()
+        {
+            TestMessage startMessage = new TestMessage();
+            MessageGate<TestMessage, OtherMessage> gate = new MessageGate<TestMessage, OtherMessage>();
+            bool executed = false;
+            
+            using Timer timer = new Timer(state =>
+                                          {
+                                              ExceptionMessage exception = new ExceptionMessage("Error", Array.Empty<Message>(), new HelloAgent(Substitute.For<IMessageBoard>()));
+                                              gate.Check(exception);
+                                              executed = true;
+                                          }, null, 200,
+                                          Timeout.Infinite);
+            MessageGateResult<OtherMessage> result = gate.SendAndAwait(startMessage, 500);
+
+            executed.Should().BeTrue("otherwise there is a timing issue.");
+            result.Result.Should().Be(MessageGateResultKind.Timeout);
+        }
+        
+        [Test]
+        public void CancelGateWithCancelToken()
+        {
+            using CancellationTokenSource source = new CancellationTokenSource(500);
+            TestMessage startMessage = new TestMessage();
+            MessageGate<TestMessage, OtherMessage> gate = new MessageGate<TestMessage, OtherMessage>();
+            
+            MessageGateResult<OtherMessage> result = gate.SendAndAwait(startMessage, cancellationToken:source.Token);
+
+            source.IsCancellationRequested.Should().BeTrue("something went wrong otherwise.");
+            result.Result.Should().Be(MessageGateResultKind.Canceled);
+        }
+        
+        private class OtherMessage : Message
+        {
+
+            protected override string DataToString()
+            {
+                return string.Empty;
+            }
+
+            public OtherMessage(Message predecessorMessage, string name = null)
+                : base(predecessorMessage, name)
+            {
+            }
+
+            public OtherMessage(IEnumerable<Message> predecessorMessages, string name = null)
+                : base(predecessorMessages, name)
+            {
+            }
+        }
+    }
+}

--- a/src/Agents.Net.Tests/SpecFlow/IntegrationTestStepDefinitions.Then.cs
+++ b/src/Agents.Net.Tests/SpecFlow/IntegrationTestStepDefinitions.Then.cs
@@ -66,5 +66,11 @@ namespace Agents.Net.Tests.SpecFlow
             context.Get<WaitingConsole>().WaitForMessages(out _);
             context.Get<ExecutionOrder>().CheckParallelMessages(agent, messageCount);
         }
+
+        [Then("the legacy service returned \"(.*)\"")]
+        public void TheLegacyServiceReturned(string serviceData)
+        {
+            context.Get<string>("LegacyServiceResult").Should().Be(serviceData);
+        }
     }
 }

--- a/src/Agents.Net.Tests/SpecFlow/IntegrationTestStepDefinitions.When.cs
+++ b/src/Agents.Net.Tests/SpecFlow/IntegrationTestStepDefinitions.When.cs
@@ -3,6 +3,8 @@
 //  This file is licensed under MIT
 #endregion
 
+using Agents.Net.Tests.Tools.Communities.LegacyServiceBridgeCommunity;
+using Autofac;
 using TechTalk.SpecFlow;
 
 namespace Agents.Net.Tests.SpecFlow
@@ -13,6 +15,13 @@ namespace Agents.Net.Tests.SpecFlow
         public void WhenIStartTheMessageBoard()
         {
             context.Get<IMessageBoard>().Start();
+        }
+        
+        [When("Call the legacy service with the data \"(true|false)\"")]
+        public void WhenICallTheLegacyService(bool data)
+        {
+            string result = context.Get<IContainer>().Resolve<ILegacyService>().ServiceCall(data);
+            context.Set(result, "LegacyServiceResult");
         }
     }
 }

--- a/src/Agents.Net.Tests/Tools/Communities/LegacyServiceBridgeCommunity/Agents/ExceptionProducer.cs
+++ b/src/Agents.Net.Tests/Tools/Communities/LegacyServiceBridgeCommunity/Agents/ExceptionProducer.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using Agents.Net;
+using Agents.Net.Tests.Tools.Communities.LegacyServiceBridgeCommunity.Messages;
+
+namespace Agents.Net.Tests.Tools.Communities.LegacyServiceBridgeCommunity.Agents
+{
+    [Produces(typeof(ExceptionMessage))]
+    [Intercepts(typeof(ServiceParameterPassed))]
+    public class ExceptionProducer : InterceptorAgent
+    {
+        public ExceptionProducer(IMessageBoard messageBoard) : base(messageBoard)
+        {
+        }
+
+        protected override InterceptionAction InterceptCore(Message messageData)
+        {
+            ServiceParameterPassed parameterPassed = messageData.Get<ServiceParameterPassed>();
+            if (parameterPassed.ThrowException)
+            {
+                OnMessage(new ExceptionMessage("Error", messageData, this));
+                return InterceptionAction.DoNotPublish;
+            }
+
+            return InterceptionAction.Continue;
+        }
+    }
+}

--- a/src/Agents.Net.Tests/Tools/Communities/LegacyServiceBridgeCommunity/Agents/ServiceBridge.cs
+++ b/src/Agents.Net.Tests/Tools/Communities/LegacyServiceBridgeCommunity/Agents/ServiceBridge.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Agents.Net;
+using Agents.Net.Tests.Tools.Communities.LegacyServiceBridgeCommunity.Messages;
+
+namespace Agents.Net.Tests.Tools.Communities.LegacyServiceBridgeCommunity.Agents
+{
+    [Consumes(typeof(ExceptionMessage))]
+    [Consumes(typeof(ServiceResult))]
+    [Produces(typeof(ServiceParameterPassed))]
+    public class ServiceBridge : Agent, ILegacyService
+    {
+        private readonly MessageGate<ServiceParameterPassed, ServiceResult> gate = new MessageGate<ServiceParameterPassed, ServiceResult>();
+        public ServiceBridge(IMessageBoard messageBoard) : base(messageBoard)
+        {
+        }
+
+        protected override void ExecuteCore(Message messageData)
+        {
+            gate.Check(messageData);
+        }
+
+        public string ServiceCall(bool throwException)
+        {
+            ServiceParameterPassed startMessage = new ServiceParameterPassed(throwException);
+            MessageGateResult<ServiceResult> result = gate.SendAndAwait(startMessage, OnMessage);
+            return result.Result == MessageGateResultKind.Success ? result.EndMessage.Result : "Exception";
+        }
+    }
+}

--- a/src/Agents.Net.Tests/Tools/Communities/LegacyServiceBridgeCommunity/Agents/ServiceExecutor.cs
+++ b/src/Agents.Net.Tests/Tools/Communities/LegacyServiceBridgeCommunity/Agents/ServiceExecutor.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using Agents.Net;
+using Agents.Net.Tests.Tools.Communities.LegacyServiceBridgeCommunity.Messages;
+
+namespace Agents.Net.Tests.Tools.Communities.LegacyServiceBridgeCommunity.Agents
+{
+    [Consumes(typeof(ServiceParameterPassed))]
+    [Produces(typeof(ServiceResult))]
+    public class ServiceExecutor : Agent
+    {
+        public ServiceExecutor(IMessageBoard messageBoard) : base(messageBoard)
+        {
+        }
+
+        protected override void ExecuteCore(Message messageData)
+        {
+            OnMessage(new ServiceResult(messageData, "ServiceCallResult"));
+        }
+    }
+}

--- a/src/Agents.Net.Tests/Tools/Communities/LegacyServiceBridgeCommunity/ILegacyService.cs
+++ b/src/Agents.Net.Tests/Tools/Communities/LegacyServiceBridgeCommunity/ILegacyService.cs
@@ -1,0 +1,7 @@
+namespace Agents.Net.Tests.Tools.Communities.LegacyServiceBridgeCommunity
+{
+    public interface ILegacyService
+    {
+        string ServiceCall(bool throwException);
+    }
+}

--- a/src/Agents.Net.Tests/Tools/Communities/LegacyServiceBridgeCommunity/LegacyServiceBridgeCommunityModule.cs
+++ b/src/Agents.Net.Tests/Tools/Communities/LegacyServiceBridgeCommunity/LegacyServiceBridgeCommunityModule.cs
@@ -1,0 +1,15 @@
+﻿using Autofac;
+using Agents.Net;
+
+namespace Agents.Net.Tests.Tools.Communities.LegacyServiceBridgeCommunity
+{
+    public class LegacyServiceBridgeCommunityModule : Module
+    {
+        protected override void Load(ContainerBuilder builder)
+        {
+            builder.RegisterType<Agents.ExceptionProducer>().As<Agent>().InstancePerLifetimeScope();
+            builder.RegisterType<Agents.ServiceExecutor>().As<Agent>().InstancePerLifetimeScope();
+            builder.RegisterType<Agents.ServiceBridge>().As<Agent>().As<ILegacyService>().InstancePerLifetimeScope();
+        }
+    }
+}

--- a/src/Agents.Net.Tests/Tools/Communities/LegacyServiceBridgeCommunity/Messages/ServiceParameterPassed.cs
+++ b/src/Agents.Net.Tests/Tools/Communities/LegacyServiceBridgeCommunity/Messages/ServiceParameterPassed.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using Agents.Net;
+
+namespace Agents.Net.Tests.Tools.Communities.LegacyServiceBridgeCommunity.Messages
+{
+    public class ServiceParameterPassed : Message
+    {
+        public ServiceParameterPassed(bool throwException): base(Array.Empty<Message>())
+        {
+            ThrowException = throwException;
+        }
+
+        public bool ThrowException { get; }
+        
+        protected override string DataToString()
+        {
+            return $"{nameof(ThrowException)}: {ThrowException}";
+        }
+    }
+}

--- a/src/Agents.Net.Tests/Tools/Communities/LegacyServiceBridgeCommunity/Messages/ServiceResult.cs
+++ b/src/Agents.Net.Tests/Tools/Communities/LegacyServiceBridgeCommunity/Messages/ServiceResult.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+using Agents.Net;
+
+namespace Agents.Net.Tests.Tools.Communities.LegacyServiceBridgeCommunity.Messages
+{
+    public class ServiceResult : Message
+    {
+        public ServiceResult(Message predecessorMessage, string result): base(predecessorMessage)
+        {
+            Result = result;
+        }
+
+        public ServiceResult(IEnumerable<Message> predecessorMessages, string result): base(predecessorMessages)
+        {
+            Result = result;
+        }
+        
+        public string Result { get; }
+
+        protected override string DataToString()
+        {
+            return $"{nameof(Result)}: {Result}";
+        }
+    }
+}

--- a/src/Agents.Net.Tests/Tools/Communities/LegacyServiceBridgeCommunity/Model.amodel
+++ b/src/Agents.Net.Tests/Tools/Communities/LegacyServiceBridgeCommunity/Model.amodel
@@ -1,0 +1,78 @@
+{
+  "GeneratorSettings": {
+    "PackageNamespace": "Agents.Net.Tests.Tools.Communities.LegacyServiceBridgeCommunity",
+    "GenerateAutofacModule": true
+  },
+  "Agents": [
+    {
+      "Id": "2f260f30-443e-4724-a55e-bbdd8e93c404",
+      "Name": "ServiceBridge",
+      "Namespace": ".Agents",
+      "ConsumingMessages": [
+        "f68a1b8a-8314-4ca2-8de4-494f1abb2e97",
+        "da055bfd-f9b4-431e-9057-d19fdbc28e9c"
+      ],
+      "ProducedMessages": [
+        "e2993706-5248-420c-81b4-16be842269f8"
+      ],
+      "IncomingEvents": [
+        "Service call from extern"
+      ],
+      "ProducedEvents": []
+    },
+    {
+      "Id": "9e892dac-71b1-4110-8938-054598bafaaa",
+      "Name": "ServiceExecutor",
+      "Namespace": ".Agents",
+      "ConsumingMessages": [
+        "e2993706-5248-420c-81b4-16be842269f8"
+      ],
+      "ProducedMessages": [
+        "da055bfd-f9b4-431e-9057-d19fdbc28e9c"
+      ],
+      "IncomingEvents": [],
+      "ProducedEvents": []
+    },
+    {
+      "$type": "Agents.Net.Designer.Model.InterceptorAgentModel, Agents.Net.Designer.Model",
+      "InterceptingMessages": [
+        "e2993706-5248-420c-81b4-16be842269f8"
+      ],
+      "Id": "1810512d-de0b-4da2-913c-01ecfd0c84ee",
+      "Name": "ExceptionProducer",
+      "Namespace": ".Agents",
+      "ConsumingMessages": [],
+      "ProducedMessages": [
+        "f68a1b8a-8314-4ca2-8de4-494f1abb2e97"
+      ],
+      "IncomingEvents": [],
+      "ProducedEvents": []
+    }
+  ],
+  "Messages": [
+    {
+      "Id": "9299db60-1da2-4967-acb9-4639a9d2c385",
+      "Name": "InitializeMessage",
+      "Namespace": "Agents.Net",
+      "BuildIn": true
+    },
+    {
+      "Id": "f68a1b8a-8314-4ca2-8de4-494f1abb2e97",
+      "Name": "ExceptionMessage",
+      "Namespace": "Agents.Net",
+      "BuildIn": true
+    },
+    {
+      "Id": "e2993706-5248-420c-81b4-16be842269f8",
+      "Name": "ServiceParameterPassed",
+      "Namespace": ".Messages",
+      "BuildIn": false
+    },
+    {
+      "Id": "da055bfd-f9b4-431e-9057-d19fdbc28e9c",
+      "Name": "ServiceResult",
+      "Namespace": ".Messages",
+      "BuildIn": false
+    }
+  ]
+}

--- a/src/Agents.Net.Tests/Tools/Communities/LegacyServiceBridgeCommunity/Model.svg
+++ b/src/Agents.Net.Tests/Tools/Communities/LegacyServiceBridgeCommunity/Model.svg
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--SvgWriter version 0.0.0.0-->
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="199.93333333333" height="396.6" id="svg2" version="1.1" xmlns="http://www.w3.org/2000/svg">
+  <g transform="translate(-0,172.79999999999995)">
+    <!--Edges-->
+    <!--nodes-->
+    <rect fill="#ffffff" fill-opacity="1" stroke="#000000" stroke-opacity="1" stroke-width="1" x="50" y="-66.4" width="92.17666666667" height="16.4" rx="3" ry="3" />
+    <text x="51" y="-53.4" font-family="Times-Roman" font-size="12" fill="#000000">InitializeMessage</text>
+    <rect fill="#ffffff" fill-opacity="1" stroke="#000000" stroke-opacity="1" stroke-width="1" x="50" y="-162.8" width="99.93333333333" height="16.4" rx="3" ry="3" />
+    <text x="51" y="-149.8" font-family="Times-Roman" font-size="12" fill="#000000">ExceptionMessage</text>
+    <!--end of nodes-->
+  </g>
+</svg>

--- a/src/Agents.Net/MessageGate.cs
+++ b/src/Agents.Net/MessageGate.cs
@@ -82,14 +82,7 @@ namespace Agents.Net
     ///
     ///     protected override void ExecuteCore(Message messageData)
     ///     {
-    ///         if (messageData.TryGet(out ExceptionMessage exceptionMessage))
-    ///         {
-    ///             gate.Check(exceptionMessage);
-    ///         }
-    ///         else
-    ///         {
-    ///             gate.Check(messageData.Get&lt;TEnd&gt;());
-    ///         }
+    ///         gate.Check(messageData);
     ///     }
     ///
     ///     public TResult ServiceCall(TParam parameters)
@@ -130,21 +123,12 @@ namespace Agents.Net
         }
 
         /// <summary>
-        /// Checks whether the provided exception message is does break the awaited <see cref="SendAndAwait"/> operation.
+        /// Checks whether the provided exception message is the end message or an exception message for the awaited <see cref="SendAndAwait"/> operation.
         /// </summary>
-        /// <param name="exceptionMessage">The exception message.</param>
+        /// <param name="message">The message to check.</param>
+        /// <returns><c>true</c>, if the message was the end message or an exception message for the <see cref="SendAndAwait"/> operation.</returns>
         /// <remarks>For an example how to use this class see the type documentation.</remarks>
-        public void Check(ExceptionMessage exceptionMessage)
-        {
-            throw new NotImplementedException();
-        }
-
-        /// <summary>
-        /// Checks whether the provided message is the end message for the awaited <see cref="SendAndAwait"/> operation. 
-        /// </summary>
-        /// <param name="endMessage">The end message.</param>
-        /// <remarks>For an example how to use this class see the type documentation.</remarks>
-        public void Check(TEnd endMessage)
+        public bool Check(Message message)
         {
             throw new NotImplementedException();
         }

--- a/src/Agents.Net/MessageGate.cs
+++ b/src/Agents.Net/MessageGate.cs
@@ -1,0 +1,152 @@
+#region Copyright
+//  Copyright (c) Tobias Wilker and contributors
+//  This file is licensed under MIT
+#endregion
+
+using System;
+using System.Threading;
+
+namespace Agents.Net
+{
+    /// <summary>
+    /// This is a helper class which allows to collect a message pair consisting of a start and an end message.
+    /// </summary>
+    /// <typeparam name="TStart">Type of the start message.</typeparam>
+    /// <typeparam name="TEnd">Type of the end message.</typeparam>
+    /// <remarks>
+    /// <para>This helper should be used with caution as it breaks the basic concept of the agent framework,
+    /// that each agent does exactly one thing. There are only two use cases were this helper should be used.
+    /// <list type="number">
+    /// <item>
+    ///     <term><b>An agent serving as a legacy bridge:</b><br/></term>
+    ///     <description>
+    ///         When working in a legacy system it is sometimes necessary to have an agent serving a service interface.
+    ///         In this case it is often so that the service call provides some parameters and expects a
+    ///         specific result.<br/>
+    ///         To achieve that the service agent needs to wait inside the service call for a specific end message.
+    ///         In addition to that, the service call need to terminate once an exception message was send. It would
+    ///         wait forever otherwise.
+    ///     </description>
+    /// </item>
+    /// <item>
+    ///     <term><b>Calling a simple basic operation inside the agent framework:</b><br/></term>
+    ///     <description>
+    ///         Let's assume the following use case: The application has a file system abstraction which can
+    ///         execute CRUD operations on files and directories. Now I want to create an agent, that creates
+    ///         a new configuration file.<br/>
+    ///         Without this class the solution would look like this:
+    /// <code>
+    ///  ---------------         -------------          --------------------------
+    /// | ConfigCreator | ----> | FileCreator | -----> | ConfigFileCreatedWatcher |
+    ///  ---------------         -------------          --------------------------
+    /// FileCreating             FileCreated            ConfigFileCreated
+    /// </code>
+    ///         The <c>ConfigCreator</c> would only create the <c>FileCreating</c> message and mark it somehow
+    ///         for the <c>ConfigFileCreatedWatcher</c> which only marks the <c>FileCreated</c> message. This would
+    ///         unnecessarily increase the amount of agents in the system.<br/>
+    ///         With this class the solution would look like this:
+    /// <code>
+    ///  ---------------          -------------
+    /// | ConfigCreator | &lt;----> | FileCreator |
+    ///  ---------------          -------------
+    /// FileCreating             FileCreated
+    /// ConfigFileCreated
+    /// </code>
+    ///         Similar are operations such as executing an external process or database operations are more examples
+    ///         were the second use case would helpful.
+    ///     </description>
+    /// </item>
+    /// </list>
+    /// </para>
+    /// <para> Internally this helper uses <see cref="MessageCollector{T1,T2}"/>s to execute the boilerplate code.
+    /// Therefore all information regarding the <see cref="MessageCollector{T1,T2}"/> applies here to, such as
+    /// considering message domains.
+    /// </para>
+    /// <para> Speaking of domains. The class will internally use a message domain to mark the start message. It is
+    /// not necessary to do this by the calling code.
+    /// </para>
+    /// </remarks>
+    /// <example>
+    /// This example shows the first use case of a legacy service call.
+    /// <code>
+    /// [Consumes(typeof(TEnd))]
+    /// [Consumes(typeof(ExceptionMessage))]
+    /// [Produces(typeof(TStart))]
+    /// public class ServiceAgentImplementation : Agent, IService
+    /// {
+    ///     private readonly MessageGate&lt;TStart,TEnd&gt; gate = new MessageGate&lt;TStart,TEnd&gt;();
+    /// 
+    ///     public ServiceAgentImplementation(IMessageBoard messageBoard) : base(messageBoard)
+    ///     {
+    ///     }
+    ///
+    ///     protected override void ExecuteCore(Message messageData)
+    ///     {
+    ///         if (messageData.TryGet(out ExceptionMessage exceptionMessage))
+    ///         {
+    ///             gate.Check(exceptionMessage);
+    ///         }
+    ///         else
+    ///         {
+    ///             gate.Check(messageData.Get&lt;TEnd&gt;());
+    ///         }
+    ///     }
+    ///
+    ///     public TResult ServiceCall(TParam parameters)
+    ///     {
+    ///         MessageGateResult&lt;TEnd&gt; result = gate.SendAndAwait(parameters);
+    ///         //evaluate result and return TResult
+    ///     }
+    /// }
+    /// </code>
+    /// </example>
+    public class MessageGate<TStart,TEnd> 
+        where TEnd : Message
+        where TStart : Message
+    {
+        /// <summary>
+        /// A constant value to tell the <see cref="MessageGate{TStart,TEnd}"/> that it has to wait forever.
+        /// </summary>
+        public const int NoTimout = -1;
+
+        /// <summary>
+        /// The method to send a start message and wait for the end message.
+        /// </summary>
+        /// <param name="startMessage">The start message.</param>
+        /// <param name="timeout">
+        /// Optionally a timeout after which the method will return, without sending the result.
+        /// By default the timeout is <see cref="NoTimout"/>
+        /// </param>
+        /// <param name="cancellationToken">
+        /// Optionally a cancellation token to cancel the wait operation. This is helpful, when for example the
+        /// imitated service call is an async method. By default no CancellationToken will be used.
+        /// </param>
+        /// <returns>The <see cref="MessageGateResult{TEnd}"/> of the operation.</returns>
+        /// <remarks>For an example how to use this class see the type documentation.</remarks>
+        public MessageGateResult<TEnd> SendAndAwait(TStart startMessage, int timeout = NoTimout,
+                                                    CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Checks whether the provided exception message is does break the awaited <see cref="SendAndAwait"/> operation.
+        /// </summary>
+        /// <param name="exceptionMessage">The exception message.</param>
+        /// <remarks>For an example how to use this class see the type documentation.</remarks>
+        public void Check(ExceptionMessage exceptionMessage)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Checks whether the provided message is the end message for the awaited <see cref="SendAndAwait"/> operation. 
+        /// </summary>
+        /// <param name="endMessage">The end message.</param>
+        /// <remarks>For an example how to use this class see the type documentation.</remarks>
+        public void Check(TEnd endMessage)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Agents.Net/MessageGateResult.cs
+++ b/src/Agents.Net/MessageGateResult.cs
@@ -1,0 +1,73 @@
+#region Copyright
+//  Copyright (c) Tobias Wilker and contributors
+//  This file is licensed under MIT
+#endregion
+
+using System.Collections.Generic;
+
+namespace Agents.Net
+{
+    /// <summary>
+    /// The result of the <see cref="MessageGate{TStart,TEnd}.SendAndAwait"/> method.
+    /// </summary>
+    /// <typeparam name="TEnd">The type of the end message</typeparam>
+    /// <remarks>See <see cref="MessageGate{TStart,TEnd}"/> to understand the usage of this class.</remarks>
+    public class MessageGateResult<TEnd> where TEnd : Message
+    {
+        /// <summary>
+        /// Instantiates the class <see cref="MessageGateResult{TEnd}"/>
+        /// </summary>
+        /// <param name="result">The result kind.</param>
+        /// <param name="endMessage">The end message.</param>
+        /// <param name="exceptions">Exception messages.</param>
+        public MessageGateResult(MessageGateResultKind result, TEnd endMessage, IEnumerable<ExceptionMessage> exceptions)
+        {
+            Result = result;
+            EndMessage = endMessage;
+            Exceptions = exceptions;
+        }
+
+        /// <summary>
+        /// The result kind. Meaning if the operation was successful or not. 
+        /// </summary>
+        public MessageGateResultKind Result { get; }
+        
+        /// <summary>
+        /// The end message. Can be <c>null</c> if the operation was not successful.
+        /// </summary>
+        public TEnd EndMessage { get; }
+        
+        /// <summary>
+        /// Exceptions that were logged during the execution.
+        /// </summary>
+        /// <remarks>
+        /// The operation stops after the first exception. But it is possible that before
+        /// the result is instantiated, that the gate received more exceptions.
+        /// </remarks>
+        public IEnumerable<ExceptionMessage> Exceptions { get; }
+    }
+
+    /// <summary>
+    /// The result kind of the <see cref="MessageGate{TStart,TEnd}.SendAndAwait"/> method.
+    /// </summary>
+    /// <remarks>See <see cref="MessageGate{TStart,TEnd}"/> to understand the usage of this enum.</remarks>
+    public enum MessageGateResultKind
+    {
+        /// <summary>
+        /// The operation was successful. Meaning the end message was found.
+        /// </summary>
+        Success,
+        /// <summary>
+        /// At least one <see cref="ExceptionMessage"/> was received during the execution.
+        /// </summary>
+        Exception,
+        /// <summary>
+        /// The operation was canceled by the <see cref="System.Threading.CancellationToken"/> provided to the <see cref="MessageGate{TStart,TEnd}.SendAndAwait"/> method.
+        /// </summary>
+        Canceled,
+        /// <summary>
+        /// The operation ran into the configured timeout.
+        /// </summary>
+        Timeout
+    }
+}


### PR DESCRIPTION
## Description

This change introduces the message gate proposed in the linked issue. With that two use cases can now be meet. First a legacy use case where a traditional service call is made. Secondly when trying to reduce the amount of agents that do not do anything useful.

Fixes #102 

## How Has This Been Tested?

- Agents.Net.Tests.Features.CoreUseCasesFeature.LegacyServiceCommunityExecutesAServiceCall
- Agents.Net.Tests.Features.CoreUseCasesFeature.LegacyServiceCommunityHandlesAnException
- Agents.Net.Tests.MessageGateTest

## Checklist:

<!-- To check one of the checkboxes just change [ ] to [x]-->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
- [x] I have added an entry to the [changelog](https://github.com/agents-net/agents.net/blob/master/CHANGELOG.md) if necessary
