### PR TITLE
Add intention to delay toke release.

### DIFF
--- a/src/Agents.Net.Tests/Features/CoreUseCases.feature
+++ b/src/Agents.Net.Tests/Features/CoreUseCases.feature
@@ -140,26 +140,26 @@ creates an exception that changes the service outcome.
     And Call the legacy service with the data "true"
 	Then the legacy service returned "Exception"
 
-    Scenario: Transaction manager community completes task
-    This scenario shows the use case of a transaction mechanism. The idea is to hav an
-    agent that starts a transaction and waits for the finished message with the help of
-    a message gate. This also shows the use of the SendAndContinue method of the message
-    gate.
-        Given I pass the command line argument "Complete" to the program
-        And I have loaded the community "TransactionManagerCommunity"
-        When I start the message board
-        Then the message "Transaction Successful" was posted after a while
-        And the program was terminated
+Scenario: Transaction manager community completes task
+This scenario shows the use case of a transaction mechanism. The idea is to hav an
+agent that starts a transaction and waits for the finished message with the help of
+a message gate. This also shows the use of the SendAndContinue method of the message
+gate.
+    Given I pass the command line argument "Complete" to the program
+    And I have loaded the community "TransactionManagerCommunity"
+    When I start the message board
+    Then the message "Transaction Successful" was posted after a while
+    And the program was terminated
 
-    Scenario: Transaction manager community rolls back on error
-    This scenario shows the use case of a transaction mechanism. The idea is to hav an
-    agent that starts a transaction and waits for the finished message with the help of
-    a message gate. The message gate comes with the handy functionality to stop the 
-    execution when there is an exception. With that it is easy to initiate a rollback.
-    In a real application the rollback than needs to revert any changes made during the
-    transaction.
-        Given I pass the command line argument "Error" to the program
-        And I have loaded the community "TransactionManagerCommunity"
-        When I start the message board
-        Then the message "Rollback" was posted after a while
-        And the program was terminated
+Scenario: Transaction manager community rolls back on error
+This scenario shows the use case of a transaction mechanism. The idea is to hav an
+agent that starts a transaction and waits for the finished message with the help of
+a message gate. The message gate comes with the handy functionality to stop the 
+execution when there is an exception. With that it is easy to initiate a rollback.
+In a real application the rollback than needs to revert any changes made during the
+transaction.
+    Given I pass the command line argument "Error" to the program
+    And I have loaded the community "TransactionManagerCommunity"
+    When I start the message board
+    Then the message "Rollback" was posted after a while
+    And the program was terminated

--- a/src/Agents.Net.Tests/Features/CoreUseCases.feature.cs
+++ b/src/Agents.Net.Tests/Features/CoreUseCases.feature.cs
@@ -653,12 +653,12 @@ this.ScenarioInitialize(scenarioInfo);
         {
             string[] tagsOfScenario = ((string[])(null));
             System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
-            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Transaction manager community completes task", @"    This scenario shows the use case of a transaction mechanism. The idea is to hav an
-    agent that starts a transaction and waits for the finished message with the help of
-    a message gate. This also shows the use of the SendAndContinue method of the message
-    gate.", tagsOfScenario, argumentsOfScenario);
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Transaction manager community completes task", @"This scenario shows the use case of a transaction mechanism. The idea is to hav an
+agent that starts a transaction and waits for the finished message with the help of
+a message gate. This also shows the use of the SendAndContinue method of the message
+gate.", tagsOfScenario, argumentsOfScenario);
 #line 143
-    this.ScenarioInitialize(scenarioInfo);
+this.ScenarioInitialize(scenarioInfo);
 #line hidden
             bool isScenarioIgnored = default(bool);
             bool isFeatureIgnored = default(bool);
@@ -678,19 +678,19 @@ this.ScenarioInitialize(scenarioInfo);
             {
                 this.ScenarioStart();
 #line 148
-        testRunner.Given("I pass the command line argument \"Complete\" to the program", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
+    testRunner.Given("I pass the command line argument \"Complete\" to the program", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
 #line hidden
 #line 149
-        testRunner.And("I have loaded the community \"TransactionManagerCommunity\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+    testRunner.And("I have loaded the community \"TransactionManagerCommunity\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
 #line 150
-        testRunner.When("I start the message board", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+    testRunner.When("I start the message board", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
 #line 151
-        testRunner.Then("the message \"Transaction Successful\" was posted after a while", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+    testRunner.Then("the message \"Transaction Successful\" was posted after a while", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
 #line 152
-        testRunner.And("the program was terminated", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+    testRunner.And("the program was terminated", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
             }
             this.ScenarioCleanup();
@@ -702,14 +702,14 @@ this.ScenarioInitialize(scenarioInfo);
         {
             string[] tagsOfScenario = ((string[])(null));
             System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
-            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Transaction manager community rolls back on error", @"    This scenario shows the use case of a transaction mechanism. The idea is to hav an
-    agent that starts a transaction and waits for the finished message with the help of
-    a message gate. The message gate comes with the handy functionality to stop the 
-    execution when there is an exception. With that it is easy to initiate a rollback.
-    In a real application the rollback than needs to revert any changes made during the
-    transaction.", tagsOfScenario, argumentsOfScenario);
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Transaction manager community rolls back on error", @"This scenario shows the use case of a transaction mechanism. The idea is to hav an
+agent that starts a transaction and waits for the finished message with the help of
+a message gate. The message gate comes with the handy functionality to stop the 
+execution when there is an exception. With that it is easy to initiate a rollback.
+In a real application the rollback than needs to revert any changes made during the
+transaction.", tagsOfScenario, argumentsOfScenario);
 #line 154
-    this.ScenarioInitialize(scenarioInfo);
+this.ScenarioInitialize(scenarioInfo);
 #line hidden
             bool isScenarioIgnored = default(bool);
             bool isFeatureIgnored = default(bool);
@@ -729,19 +729,19 @@ this.ScenarioInitialize(scenarioInfo);
             {
                 this.ScenarioStart();
 #line 161
-        testRunner.Given("I pass the command line argument \"Error\" to the program", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
+    testRunner.Given("I pass the command line argument \"Error\" to the program", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
 #line hidden
 #line 162
-        testRunner.And("I have loaded the community \"TransactionManagerCommunity\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+    testRunner.And("I have loaded the community \"TransactionManagerCommunity\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
 #line 163
-        testRunner.When("I start the message board", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+    testRunner.When("I start the message board", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
 #line 164
-        testRunner.Then("the message \"Rollback\" was posted after a while", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+    testRunner.Then("the message \"Rollback\" was posted after a while", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
 #line 165
-        testRunner.And("the program was terminated", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+    testRunner.And("the program was terminated", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
             }
             this.ScenarioCleanup();

--- a/src/Agents.Net.Tests/Features/MessageBoardUseCases.feature
+++ b/src/Agents.Net.Tests/Features/MessageBoardUseCases.feature
@@ -25,6 +25,17 @@ the message board needs to send an exception message.
 	When I start the message board
 	Then the message "Interception conflict detected." was posted after a while
 	And the program was terminated
+
+Scenario: Stop publishing after delay
+This scenario shows the feature, an interceptor agent delays a message and later decides to 
+not publish the message. In this case the intention can be passed to the delay token release
+method. Once at least one token has the intention to not publish the final message, then the
+delayed message will not be published. 
+    Given I pass the command line argument "DoNotPublish intention" to the program
+	And I have loaded the community "DelayCommunity"
+	When I start the message board
+	Then the message "Delayed message was not published." was posted after a while
+	And the program was not terminated
 	
 @DisposeCheck
 Scenario: Dispose messages after they were used

--- a/src/Agents.Net.Tests/Features/MessageBoardUseCases.feature.cs
+++ b/src/Agents.Net.Tests/Features/MessageBoardUseCases.feature.cs
@@ -173,22 +173,16 @@ this.ScenarioInitialize(scenarioInfo);
         }
         
         [NUnit.Framework.TestAttribute()]
-        [NUnit.Framework.DescriptionAttribute("Dispose messages after they were used")]
-        [NUnit.Framework.CategoryAttribute("DisposeCheck")]
-        public virtual void DisposeMessagesAfterTheyWereUsed()
+        [NUnit.Framework.DescriptionAttribute("Stop publishing after delay")]
+        public virtual void StopPublishingAfterDelay()
         {
-            string[] tagsOfScenario = new string[] {
-                    "DisposeCheck"};
+            string[] tagsOfScenario = ((string[])(null));
             System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
-            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Dispose messages after they were used", @"This scenario shows the feature, that messages are disposed after they were
-used. The heuristic that is used to determine whether a message is used or not
-is complex as the agents themself cannot determine that as they do not know 
-how many agents react to the message. The heuristic used to determine when a 
-message can be disposed is that by default after the Execute method of any
-Agent the message will count it as used. After it was used as many times as
-there are agents it will dispose itself. The community used will have different
-messages. Afterwards it is checked whether all messages are disposed ", tagsOfScenario, argumentsOfScenario);
-#line 30
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Stop publishing after delay", @"This scenario shows the feature, an interceptor agent delays a message and later decides to 
+not publish the message. In this case the intention can be passed to the delay token release
+method. Once at least one token has the intention to not publish the final message, then the
+delayed message will not be published. ", tagsOfScenario, argumentsOfScenario);
+#line 29
 this.ScenarioInitialize(scenarioInfo);
 #line hidden
             bool isScenarioIgnored = default(bool);
@@ -208,16 +202,71 @@ this.ScenarioInitialize(scenarioInfo);
             else
             {
                 this.ScenarioStart();
-#line 39
- testRunner.Given("I have loaded the community \"DefaultDisposeCommunity\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
+#line 34
+    testRunner.Given("I pass the command line argument \"DoNotPublish intention\" to the program", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
 #line hidden
-#line 40
+#line 35
+ testRunner.And("I have loaded the community \"DelayCommunity\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 36
  testRunner.When("I start the message board", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
+#line 37
+ testRunner.Then("the message \"Delayed message was not published.\" was posted after a while", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line hidden
+#line 38
+ testRunner.And("the program was not terminated", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+            }
+            this.ScenarioCleanup();
+        }
+        
+        [NUnit.Framework.TestAttribute()]
+        [NUnit.Framework.DescriptionAttribute("Dispose messages after they were used")]
+        [NUnit.Framework.CategoryAttribute("DisposeCheck")]
+        public virtual void DisposeMessagesAfterTheyWereUsed()
+        {
+            string[] tagsOfScenario = new string[] {
+                    "DisposeCheck"};
+            System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Dispose messages after they were used", @"This scenario shows the feature, that messages are disposed after they were
+used. The heuristic that is used to determine whether a message is used or not
+is complex as the agents themself cannot determine that as they do not know 
+how many agents react to the message. The heuristic used to determine when a 
+message can be disposed is that by default after the Execute method of any
+Agent the message will count it as used. After it was used as many times as
+there are agents it will dispose itself. The community used will have different
+messages. Afterwards it is checked whether all messages are disposed ", tagsOfScenario, argumentsOfScenario);
 #line 41
+this.ScenarioInitialize(scenarioInfo);
+#line hidden
+            bool isScenarioIgnored = default(bool);
+            bool isFeatureIgnored = default(bool);
+            if ((tagsOfScenario != null))
+            {
+                isScenarioIgnored = tagsOfScenario.Where(__entry => __entry != null).Where(__entry => String.Equals(__entry, "ignore", StringComparison.CurrentCultureIgnoreCase)).Any();
+            }
+            if ((this._featureTags != null))
+            {
+                isFeatureIgnored = this._featureTags.Where(__entry => __entry != null).Where(__entry => String.Equals(__entry, "ignore", StringComparison.CurrentCultureIgnoreCase)).Any();
+            }
+            if ((isScenarioIgnored || isFeatureIgnored))
+            {
+                testRunner.SkipScenario();
+            }
+            else
+            {
+                this.ScenarioStart();
+#line 50
+ testRunner.Given("I have loaded the community \"DefaultDisposeCommunity\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
+#line hidden
+#line 51
+ testRunner.When("I start the message board", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+#line 52
  testRunner.Then("the program was terminated", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
-#line 42
+#line 53
  testRunner.And("all messages are disposed", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
             }

--- a/src/Agents.Net.Tests/Tools/Communities/DelayCommunity/Agents/InformationBroker.cs
+++ b/src/Agents.Net.Tests/Tools/Communities/DelayCommunity/Agents/InformationBroker.cs
@@ -24,7 +24,11 @@ namespace Agents.Net.Tests.Tools.Communities.DelayCommunity.Agents
         {
             if (args.Arguments.FirstOrDefault() == "simulate interception conflict")
             {
-                OnMessage(new InformationGathered("Special Conflict", messageData));
+                OnMessage(new InformationGathered("Conflict", messageData));
+            }
+            else if (args.Arguments.FirstOrDefault() == "DoNotPublish intention")
+            {
+                OnMessage(new InformationGathered("DoNotPublish", messageData));
             }
             else
             {

--- a/src/Agents.Net/InterceptionDelayToken.cs
+++ b/src/Agents.Net/InterceptionDelayToken.cs
@@ -17,8 +17,8 @@ namespace Agents.Net
             
         }
         
-        private Action onRelease;
-        internal void Register(Action onRelease)
+        private Action<DelayTokenReleaseIntention> onRelease;
+        internal void Register(Action<DelayTokenReleaseIntention> onRelease)
         {
             this.onRelease = onRelease;
         }
@@ -26,9 +26,28 @@ namespace Agents.Net
         /// <summary>
         /// Release the message. After this the intercepted message will be send.
         /// </summary>
-        public void Release()
+        /// <param name="intention">Indicates whether to publish the delayed message or not.</param>
+        /// <remarks>
+        /// If at least one <see cref="InterceptionDelayToken"/> returns the intention <see cref="DelayTokenReleaseIntention.DoNotPublish"/> the delayed message is not published.
+        /// </remarks>
+        public void Release(DelayTokenReleaseIntention intention = DelayTokenReleaseIntention.Publish)
         {
-            onRelease?.Invoke();
+            onRelease?.Invoke(intention);
         }
+    }
+
+    /// <summary>
+    /// The intention for the <see cref="InterceptionDelayToken.Release"/> method.
+    /// </summary>
+    public enum DelayTokenReleaseIntention
+    {
+        /// <summary>
+        /// Publish the delayed message
+        /// </summary>
+        Publish,
+        /// <summary>
+        /// Do not publish the delayed message
+        /// </summary>
+        DoNotPublish
     }
 }


### PR DESCRIPTION
## Description

This adds an intention to the delay token release method in order to stop publishing the delayed message.

Fixes #106

## How Has This Been Tested?

- Agents.Net.Tests.Features.MessageBoardUseCasesFeature.StopPublishingAfterDelay

## Checklist:

<!-- To check one of the checkboxes just change [ ] to [x]-->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
- [x] I have added an entry to the [changelog](https://github.com/agents-net/agents.net/blob/master/CHANGELOG.md) if necessary
