### PR TITLE
Do not check messages if the message gate is inactive.

### DIFF
--- a/src/Agents.Net.Tests/MessageGateTest.cs
+++ b/src/Agents.Net.Tests/MessageGateTest.cs
@@ -151,10 +151,19 @@ namespace Agents.Net.Tests
         [Test]
         public void DoNotExceptForeignMessages()
         {
-            using CancellationTokenSource source = new(500);
             MessageGate<TestMessage, OtherMessage> gate = new();
+            gate.SendAndContinue(new TestMessage(), _=> {}, _=>{});
 
             bool checkResult = gate.Check(new ForeignMessage());
+            checkResult.Should().BeFalse("Foreign messages should not be excepted.");
+        }
+        
+        [Test]
+        public void DoNotExceptMessagesWithoutAwaitingExecution()
+        {
+            MessageGate<TestMessage, OtherMessage> gate = new();
+
+            bool checkResult = gate.Check(new OtherMessage(ArraySegment<Message>.Empty));
             checkResult.Should().BeFalse("Foreign messages should not be excepted.");
         }
         

--- a/src/Agents.Net/MessageGate.cs
+++ b/src/Agents.Net/MessageGate.cs
@@ -319,6 +319,8 @@ namespace Agents.Net
             }
         }
 
+        private bool IsActive => exceptions.Count > 0;
+
         /// <summary>
         /// Checks whether the provided exception message is the end message or an exception message for the awaited <see cref="SendAndAwait"/> operation.
         /// </summary>
@@ -327,6 +329,11 @@ namespace Agents.Net
         /// <remarks>For an example how to use this class see the type documentation.</remarks>
         public bool Check(Message message)
         {
+            if (!IsActive)
+            {
+                //do not store messages if no messages are awaited
+                return false;
+            }
             bool result = exceptionCollector.TryPush(message);
             result |= pairCollector.TryPush(message);
             return result;


### PR DESCRIPTION
## Description

When the message gate does not await any messages no message must be stored.

## How Has This Been Tested?

- Agents.Net.Tests.MessageGateTest.DoNotExceptMessagesWithoutAwaitingExecution

## Checklist:

<!-- To check one of the checkboxes just change [ ] to [x]-->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
- [x] I have added an entry to the [changelog](https://github.com/agents-net/agents.net/blob/master/CHANGELOG.md) if necessary
