### PR TITLE
Messages are now disposed if removed from collector.

### DIFF
--- a/src/Agents.Net.Tests/DisposeTests.cs
+++ b/src/Agents.Net.Tests/DisposeTests.cs
@@ -1,0 +1,155 @@
+#region Copyright
+//  Copyright (c) Tobias Wilker and contributors
+//  This file is licensed under MIT
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Agents.Net.Tests
+{
+    /// <summary>
+    /// This class simulates the interactions between the message board and the messages regarding disposing the messages.
+    /// </summary>
+    /// <remarks>
+    /// The message board uses SetUserCount(x) to set the number of agents that use the message.
+    /// After each agent execution the message is called with Used() once.
+    /// Once no more uses are there, the message is disposed.
+    /// </remarks>
+    public class DisposeTests
+    {
+        [Test]
+        public void MessageIsDisposedAfterOnlyUse()
+        {
+            DisposableMessage message = new();
+            message.SetUserCount(1);
+            message.Used();
+
+            message.IsDisposed.Should().BeTrue("no one blocked the dispose action.");
+        }
+        
+        [Test]
+        public void MessageNotDisposedIfHeldByDelay()
+        {
+            DisposableMessage message = new();
+            message.SetUserCount(1);
+            message.DelayDispose();
+            message.Used();
+
+            message.IsDisposed.Should().BeFalse("the delay blocked the dispose.");
+        }
+        
+        [Test]
+        public void MessageIsDisposedIfDelayIsReleased()
+        {
+            DisposableMessage message = new();
+            message.SetUserCount(1);
+            IDisposable token = message.DelayDispose();
+            message.Used();
+            token.Dispose();
+
+            message.IsDisposed.Should().BeTrue("the delay blocked the dispose.");
+        }
+        
+        [Test]
+        public void MessageNotDisposedIfHeldByCollector()
+        {
+            MessageCollector<TestMessage, DisposableMessage> collector = new();
+            DisposableMessage message = new();
+            message.SetUserCount(1);
+            collector.Push(message);
+            message.Used();
+
+            message.IsDisposed.Should().BeFalse("the collector blocked the dispose.");
+        }
+        
+        [Test]
+        public void MessageIsDisposedIfCollectorIsExecuted()
+        {
+            MessageCollector<TestMessage, DisposableMessage> collector = new(set =>
+            {
+                set.Message2.IsDisposed.Should().BeFalse("I am still using it.");
+            });
+            DisposableMessage message = new();
+            message.SetUserCount(1);
+            collector.Push(message);
+            message.Used();
+            collector.Push(new TestMessage());
+
+            message.IsDisposed.Should().BeTrue("the collector is finished.");
+        }
+        
+        [Test]
+        public void MessageIsDisposedIfRemovedFromCollectorByDomainTermination()
+        {
+            MessageCollector<TestMessage, DisposableMessage> collector = new();
+            DisposableMessage message = new();
+            MessageDomain.CreateNewDomainsFor(message);
+            message.SetUserCount(1);
+            collector.Push(message);
+            message.Used();
+            MessageDomain.TerminateDomainsOf(message);
+
+            message.IsDisposed.Should().BeTrue("the it was removed from the collector.");
+        }
+        
+        [Test]
+        public void MessageNotDisposedIfHeldByAggregator()
+        {
+            MessageAggregator<DisposableMessage> aggregator = new(_ =>{});
+            DisposableMessage message = new();
+            DisposableMessage message2 = new();
+            MessageDomain.CreateNewDomainsFor(new []{message, message2});
+            message.SetUserCount(1);
+            aggregator.Aggregate(message);
+            message.Used();
+
+            message.IsDisposed.Should().BeFalse("the aggregator blocked the dispose.");
+        }
+        
+        [Test]
+        public void MessageIsDisposedIfAggregatorIsExecuted()
+        {
+            DisposableMessage message = new();
+            message.SetUserCount(1);
+            DisposableMessage message2 = new();
+            MessageDomain.CreateNewDomainsFor(new []{message, message2});
+            MessageAggregator<DisposableMessage> aggregator = new(set =>
+            {
+                message.IsDisposed.Should().BeFalse("I am using it.");
+            });
+            aggregator.Aggregate(message);
+            message.Used();
+            aggregator.Aggregate(message2);
+
+            message.IsDisposed.Should().BeTrue("the aggregator is finished.");
+        }
+
+        private class DisposableMessage : Message
+        {
+            public DisposableMessage()
+                : base(Enumerable.Empty<Message>())
+            {
+            }
+            
+            public bool IsDisposed { get; private set; }
+
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    IsDisposed = true;
+                }
+                base.Dispose(disposing);
+            }
+
+            protected override string DataToString()
+            {
+                return string.Empty;
+            }
+        }
+    }
+}

--- a/src/Agents.Net.Tests/Features/CoreUseCases.feature
+++ b/src/Agents.Net.Tests/Features/CoreUseCases.feature
@@ -83,7 +83,7 @@ commiting agent is using.
 	Given I have loaded the community "DelayCommunity"
 	When I start the message board
 	Then the message "Transformed Information" was posted after at most 1000 ms
-	And the message "Special Information" was posted after a while
+	And the message "Special Information" was posted after at most 1000 ms
 	And the program was terminated
 
 Scenario: Precondition check community prints error message to console

--- a/src/Agents.Net.Tests/Features/CoreUseCases.feature.cs
+++ b/src/Agents.Net.Tests/Features/CoreUseCases.feature.cs
@@ -400,7 +400,7 @@ this.ScenarioInitialize(scenarioInfo);
  testRunner.Then("the message \"Transformed Information\" was posted after at most 1000 ms", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
 #line 86
- testRunner.And("the message \"Special Information\" was posted after a while", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+ testRunner.And("the message \"Special Information\" was posted after at most 1000 ms", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
 #line 87
  testRunner.And("the program was terminated", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");

--- a/src/Agents.Net/MessageCollector.cs
+++ b/src/Agents.Net/MessageCollector.cs
@@ -450,7 +450,10 @@ namespace Agents.Net
             else
             {
                 messagePool.Add(message.MessageDomain, message);
-                message.MessageDomain.ExecuteOnTerminate(() => messagePool.Remove(message.MessageDomain));
+                message.MessageDomain.ExecuteOnTerminate(() =>
+                {
+                    message.Used();
+                });
             }
         }
 


### PR DESCRIPTION
## Description

There was a small performance leak if a message was removed from the message collector, that is was in fact not disposed. Not it is disposed as well.

## How Has This Been Tested?

- Agents.Net.Tests.DisposeTests

## Checklist:

<!-- To check one of the checkboxes just change [ ] to [x]-->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
- [x] I have added an entry to the [changelog](https://github.com/agents-net/agents.net/blob/master/CHANGELOG.md) if necessary
